### PR TITLE
fix: pass None for writer in messenger_handler Anthropic calls

### DIFF
--- a/src/gateway/messenger_handler.rs
+++ b/src/gateway/messenger_handler.rs
@@ -324,7 +324,7 @@ async fn process_incoming_message(
 
     for _round in 0..MAX_TOOL_ROUNDS {
         let result = if resolved.provider == "anthropic" {
-            providers::call_anthropic_with_tools(http, &resolved).await
+            providers::call_anthropic_with_tools(http, &resolved, None).await
         } else if resolved.provider == "google" {
             providers::call_google_with_tools(http, &resolved).await
         } else {


### PR DESCRIPTION
Quick fix for the build error from PR #6.

The messenger handler doesn't have a TUI WebSocket writer, so it needs to pass `None` for the writer argument to use batch mode.

One-liner fix.