### PR TITLE
fix(tui): remove password prompt on launch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -522,16 +522,14 @@ async fn main() -> Result<()> {
             if let Some(url) = &args.url {
                 config.gateway_url = Some(url.clone());
             }
-            let mut app = if config.secrets_password_protected {
-                let pw = if let Some(pw) = args.password {
-                    pw
-                } else {
-                    prompt_password("Enter secrets vault password: ")?
-                };
-                App::with_password(config, pw)?
-            } else {
-                App::new(config)?
-            };
+            // Password handling has moved to the gateway. The TUI connects
+            // and, if the vault is locked, the gateway sends a vault_locked
+            // frame which triggers an interactive unlock prompt in the TUI.
+            // A password passed via --password is forwarded after connect.
+            let mut app = App::new(config)?;
+            if let Some(pw) = args.password {
+                app.set_deferred_vault_password(pw);
+            }
             app.run().await?;
         }
 


### PR DESCRIPTION
## Problem

The TUI prompts for the vault password at startup, blocking launch. This is unnecessary since:
- TOTP already authenticates the client to the gateway
- The gateway has its own `vault_locked` / `unlock_vault` protocol for handling this interactively

## Changes

**main.rs**: TUI launch no longer branches on `secrets_password_protected`. Always creates `App::new()`. If `--password` is passed, it's stored as a deferred password.

**app.rs**: 
- Added `deferred_vault_password: Option<String>` field
- Added `set_deferred_vault_password()` method  
- When gateway sends `vault_locked`, if a deferred password exists, it's automatically forwarded via the existing `Action::GatewayUnlockVault` path
- If no deferred password, falls through to the interactive prompt (existing behavior)

## Result

- `rustyclaw tui` → launches immediately, prompts for password in-app only if vault is locked
- `rustyclaw tui --password foo` → launches and auto-unlocks vault
