### PR TITLE
perf(tui): cache parsed markdown lines with OnceCell

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1177,7 +1177,7 @@ impl App {
                 if !self.showing_hatching {
                     // Update the last assistant message with accumulated text.
                     if let Some(last) = self.state.messages.last_mut() {
-                        last.content = buf.clone();
+                        last.update_content(buf.clone());
                         debug_log(&format!("Updated last message to {} chars", last.content.len()));
                     } else {
                         debug_log("WARNING: No last message to update!");


### PR DESCRIPTION
## Problem

`build_lines()` was called multiple times per frame — during rendering, scroll calculation, visual line counting, and copy operations. Each call re-parsed markdown, causing unnecessary CPU usage at 60fps.

## Solution

`OnceCell`-based lazy caching in `DisplayMessage`:

- `get_lines()` computes styled lines once, returns cached reference
- `update_content()` invalidates cache (used during streaming)  
- Only assistant messages go through `tui-markdown`
- Other roles (user, system, tool, etc.) use simple styled spans

## Impact

Markdown parsing goes from ~4× per frame → once per message lifetime (or once per streaming update).
