### PR TITLE
fix(tui): restore local vault access for secrets management

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -646,9 +646,13 @@ impl App {
                 // Send the password to the gateway as an unlock_vault frame.
                 let frame = serde_json::json!({
                     "type": "unlock_vault",
-                    "password": password,
+                    "password": password.clone(),
                 });
                 self.send_to_gateway(frame.to_string()).await;
+                // Also unlock the local SecretsManager so the TUI can
+                // list, store, and read secrets without going through
+                // the gateway.
+                self.state.secrets_manager.set_password(password.clone());
                 self.state
                     .messages
                     .push(DisplayMessage::info("Sent vault unlock request…"));


### PR DESCRIPTION
## Problem

PR #10 removed the password prompt at TUI launch to simplify the flow. But the TUI needs local vault access for:
- Listing secrets in the secrets pane
- Storing new API keys via the dialog
- Reading keys for provider probing

Without it, the secrets pane shows empty and newly entered API keys can't be stored → they never reach the provider.

## Fix

- Restore the password prompt at launch when `secrets_password_protected = true`
- When forwarding the vault password to the gateway, also `set_password()` on the local `SecretsManager`
- `--password` flag continues to work

This means the TUI behaves exactly as before PR #10, but the gateway unlock path also shares the password with the local vault.
