### PR TITLE
feat: add gateway reload command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,6 +26,8 @@ pub enum CommandAction {
     ShowSecrets,
     /// Show the provider selector dialog
     ShowProviderSelector,
+    /// Reload gateway configuration
+    GatewayReload,
     /// Download media by ID (id, optional destination path)
     Download(String, Option<String>),
 }
@@ -57,6 +59,7 @@ pub fn command_names() -> Vec<String> {
         "gateway start".into(),
         "gateway stop".into(),
         "gateway restart".into(),
+        "reload".into(),
         "provider".into(),
         "model".into(),
         "skills".into(),
@@ -113,6 +116,7 @@ pub fn handle_command(input: &str, context: &mut CommandContext<'_>) -> CommandR
                 "  /gateway start           - Connect to the gateway".to_string(),
                 "  /gateway stop            - Disconnect from the gateway".to_string(),
                 "  /gateway restart         - Restart the gateway connection".to_string(),
+                "  /reload                  - Reload gateway config (no restart)".to_string(),
                 "  /provider <name>         - Change the AI provider".to_string(),
                 "  /model <name>            - Change the AI model".to_string(),
                 "  /skills                  - Show loaded skills".to_string(),
@@ -206,6 +210,10 @@ pub fn handle_command(input: &str, context: &mut CommandContext<'_>) -> CommandR
                 messages: Vec::new(),
                 action: CommandAction::GatewayInfo,
             },
+        },
+        "reload" => CommandResponse {
+            messages: vec!["Reloading gateway configuration…".to_string()],
+            action: CommandAction::GatewayReload,
         },
         "skills" => CommandResponse {
             messages: Vec::new(),


### PR DESCRIPTION
## Summary

Adds `rustyclaw gateway reload` CLI subcommand and `/reload` TUI command that hot-reloads the gateway configuration without restarting the process or dropping connections.

## What reload does

1. Re-reads `config.toml` from disk
2. Re-resolves model context (provider, model, base_url, api_key) from the vault
3. Updates shared state so both **new and existing connections** use the updated config
4. Sends a `reload_result` confirmation frame back to the requesting client
5. Sends a `model_configured` status update with the new model info

## Architecture

- **Shared state types**: `SharedConfig` (`Arc<RwLock<Config>>`) and `SharedModelCtx` (`Arc<RwLock<Option<Arc<ModelContext>>>>`)
- `run_gateway` wraps config and model_ctx in shared state, passes to `handle_connection`
- `handle_connection` snapshots config at connection start but reads model_ctx from shared state on each dispatch — so reload takes effect on existing connections immediately
- CLI reload connects via WebSocket, handles TOTP auth if needed, sends reload command and waits for result
- TUI `/reload` sends the reload frame and displays the result

## Files changed

| File | Changes |
|------|--------|
| `src/gateway/mod.rs` | Shared state types, reload handler, updated `handle_connection` signature |
| `src/main.rs` | `GatewayCommands::Reload` variant + `send_gateway_reload` helper |
| `src/commands.rs` | `/reload` command + `GatewayReload` action |
| `src/app.rs` | `reload_result` frame handler + `GatewayReload` action dispatch |

## Testing

- `cargo check` passes with no new warnings
- CLI: `rustyclaw gateway reload` connects, authenticates, sends reload, displays result
- TUI: `/reload` sends reload frame, displays success/failure message