### PR TITLE
fix(tui): wrap rendered tables in code block to preserve newlines

### DIFF
--- a/src/panes/mod.rs
+++ b/src/panes/mod.rs
@@ -371,7 +371,8 @@ fn render_table(lines: &[&str]) -> String {
     }
     output.push('\n');
     
-    output
+    // Wrap in a code block so tui-markdown preserves newlines
+    format!("```text\n{}\n```\n", output.trim_end())
 }
 
 /// A single message in the chat / log pane.


### PR DESCRIPTION
## Problem

The ASCII table is being rendered correctly, but tui-markdown then strips the newlines, causing all rows to collapse onto one line.

## Solution

Wrap the rendered table in ```text ... ``` so tui-markdown treats it as preformatted code and preserves the newlines.

## Result

Tables now display with proper line breaks:
```
┌──────────┬─────────────────┬───────┐
│ Language │ Paradigm(s)     │ Year  │
├──────────┼─────────────────┼───────┤
│ Rust     │ Systems         │ 2010  │
│ Python   │ Multi-paradigm  │ 1991  │
└──────────┴─────────────────┴───────┘
```