### PR TITLE
fix: revert to text WebSocket frames for gateway communication

### DIFF
--- a/src/app/handlers/gateway.rs
+++ b/src/app/handlers/gateway.rs
@@ -149,19 +149,8 @@ impl App {
 
     pub async fn send_to_gateway(&mut self, text: String) {
         if let Some(ref mut sink) = self.ws_sink {
-            let json_value: serde_json::Value = serde_json::from_str(&text).unwrap_or_else(|_| {
-                serde_json::json!({ "type": "chat", "messages": [], "content": text })
-            });
-            let bytes = match serde_json::to_vec(&json_value) {
-                Ok(b) => b,
-                Err(err) => {
-                    self.chat_loading_tick = None;
-                    self.state.loading_line = None;
-                    self.state.messages.push(DisplayMessage::error(format!("Serialization failed: {}", err)));
-                    return;
-                }
-            };
-            match sink.send(Message::Binary(bytes.into())).await {
+            // Send as text frame (JSON)
+            match sink.send(Message::Text(text.into())).await {
                 Ok(()) => {}
                 Err(err) => {
                     self.chat_loading_tick = None;


### PR DESCRIPTION
The binary frame change in commit 6702eaf broke auth because OpenClaw expects text frames for the auth protocol.

## Problem
After entering the TOTP code, the client would hang at 'Sent authentication code…' because the gateway wasn't responding to binary frames for the auth_response message.

## Solution
Revert send_to_gateway to use Message::Text instead of Message::Binary.

The gateway still handles binary frames for receiving (with String::from_utf8_lossy), but outgoing frames need to be text for the legacy auth protocol.