### PR TITLE
feat: use bincode serialization for client-gateway protocol

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -6,7 +6,7 @@ use crate::dialogs::{
     FetchModelsLoading, ModelSelectorState, PolicyPickerState, ProviderSelectorState,
     SecretViewerState, TotpDialogPhase, TotpDialogState, VaultUnlockPromptState, SPINNER_FRAMES,
 };
-use crate::gateway::ChatMessage;
+use crate::gateway::{ChatMessage, ClientFrame, ClientFrameType, ClientPayload};
 use crate::pages::hatching::Hatching;
 use crate::pages::home::Home;
 use crate::pages::Page;
@@ -473,11 +473,11 @@ impl App {
                 return Ok(Some(Action::Update));
             }
             Action::GatewayAuthResponse(code) => {
-                let frame = serde_json::json!({
-                    "type": "auth_response",
-                    "code": code,
-                });
-                self.send_to_gateway(frame.to_string()).await;
+                let frame = ClientFrame {
+                    frame_type: ClientFrameType::AuthResponse,
+                    payload: ClientPayload::AuthResponse { code: code.clone() },
+                };
+                self.send_frame(frame).await;
                 self.state
                     .messages
                     .push(DisplayMessage::info("Sent authentication code…"));

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -19,7 +19,7 @@ mod types;
 // Re-export protocol types
 pub use protocol::{
     ClientFrameType, ServerFrameType, StatusType, ServerFrame, ClientFrame,
-    serialize_frame, deserialize_frame, ServerPayload,
+    serialize_frame, deserialize_frame, ServerPayload, ClientPayload,
 };
 
 // Re-export public types

--- a/src/gateway/protocol.rs
+++ b/src/gateway/protocol.rs
@@ -155,7 +155,6 @@ pub struct ClientFrame {
 
 /// Payload variants for client frames.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "data")]
 pub enum ClientPayload {
     Empty,
     AuthResponse {
@@ -203,7 +202,6 @@ pub struct ServerFrame {
 
 /// Payload variants for server frames.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "data")]
 pub enum ServerPayload {
     Empty,
     Hello {

--- a/src/main.rs
+++ b/src/main.rs
@@ -800,7 +800,7 @@ async fn main() -> Result<()> {
 
                     // Resolve model context from the vault.
                     let model_ctx = {
-                        let mut v = shared_vault.blocking_lock();
+                        let mut v = shared_vault.lock().await;
                         match ModelContext::resolve(&config, &mut v) {
                             Ok(ctx) => {
                                 println!(


### PR DESCRIPTION
## Changes

- **Gateway auth.rs**: Deserialize `ClientFrame` with bincode instead of JSON
- **Client**: Add `send_frame()` method for typed bincode serialization  
- **Client**: Update `GatewayAuthResponse` to use `ClientFrame` with bincode
- **Export `ClientPayload`** from gateway module

## Protocol

The auth flow now uses proper bincode serialization:

```
Client                          Gateway
   |                               |
   |<-- AuthChallenge (text/JSON) -|  (gateway still sends JSON for now)
   |                               |
   |-- ClientFrame (bincode) ----->|  ClientFrameType::AuthResponse
   |                               |
   |<-- auth_result (text/JSON) ---|  (gateway still sends JSON for now)
```

## Next Steps

This is the first step toward full binary protocol. Other message types still use the legacy JSON `send_to_gateway()` and need migration:
- Vault unlock
- Secrets operations  
- Chat messages
- Cancel

The gateway also needs to migrate from JSON to bincode for outgoing frames.