### PR TITLE
feat: Import runtime and observability modules from ZeroClaw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ ssh-key = { version = "0.6", features = ["ed25519", "getrandom", "std"] }
 # File system and path handling
 dirs = "6.0"
 shellexpand = "3.1"
+directories = "6.0"
 
 # Async runtime (for messenger support)
 tokio = { version = "1.35", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,10 @@ pub mod sandbox;
 pub mod secrets;
 pub mod security;
 pub mod sessions;
+
+// Imported from ZeroClaw (MIT OR Apache-2.0 licensed)
+pub mod observability;
+pub mod runtime;
 pub mod skills;
 pub mod soul;
 pub mod streaming;

--- a/src/observability/log.rs
+++ b/src/observability/log.rs
@@ -1,0 +1,203 @@
+//! Log-based observer implementation.
+//!
+//! Zero external dependencies beyond `tracing`. Writes events and metrics
+//! as structured logs via the tracing framework.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+use super::traits::{Observer, ObserverEvent, ObserverMetric};
+use std::any::Any;
+use tracing::info;
+
+/// Log-based observer — uses tracing, zero external deps
+pub struct LogObserver;
+
+impl LogObserver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LogObserver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Observer for LogObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        match event {
+            ObserverEvent::AgentStart { provider, model } => {
+                info!(provider = %provider, model = %model, "agent.start");
+            }
+            ObserverEvent::AgentEnd {
+                provider,
+                model,
+                duration,
+                tokens_used,
+                cost_usd,
+            } => {
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                info!(provider = %provider, model = %model, duration_ms = ms, tokens = ?tokens_used, cost_usd = ?cost_usd, "agent.end");
+            }
+            ObserverEvent::ToolCallStart { tool } => {
+                info!(tool = %tool, "tool.start");
+            }
+            ObserverEvent::ToolCall {
+                tool,
+                duration,
+                success,
+            } => {
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                info!(tool = %tool, duration_ms = ms, success = success, "tool.call");
+            }
+            ObserverEvent::TurnComplete => {
+                info!("turn.complete");
+            }
+            ObserverEvent::ChannelMessage { channel, direction } => {
+                info!(channel = %channel, direction = %direction, "channel.message");
+            }
+            ObserverEvent::HeartbeatTick => {
+                info!("heartbeat.tick");
+            }
+            ObserverEvent::Error { component, message } => {
+                info!(component = %component, error = %message, "error");
+            }
+            ObserverEvent::LlmRequest {
+                provider,
+                model,
+                messages_count,
+            } => {
+                info!(
+                    provider = %provider,
+                    model = %model,
+                    messages_count = messages_count,
+                    "llm.request"
+                );
+            }
+            ObserverEvent::LlmResponse {
+                provider,
+                model,
+                duration,
+                success,
+                error_message,
+                input_tokens,
+                output_tokens,
+            } => {
+                let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+                info!(
+                    provider = %provider,
+                    model = %model,
+                    duration_ms = ms,
+                    success = success,
+                    error = ?error_message,
+                    input_tokens = ?input_tokens,
+                    output_tokens = ?output_tokens,
+                    "llm.response"
+                );
+            }
+        }
+    }
+
+    fn record_metric(&self, metric: &ObserverMetric) {
+        match metric {
+            ObserverMetric::RequestLatency(d) => {
+                let ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+                info!(latency_ms = ms, "metric.request_latency");
+            }
+            ObserverMetric::TokensUsed(t) => {
+                info!(tokens = t, "metric.tokens_used");
+            }
+            ObserverMetric::ActiveSessions(s) => {
+                info!(sessions = s, "metric.active_sessions");
+            }
+            ObserverMetric::QueueDepth(d) => {
+                info!(depth = d, "metric.queue_depth");
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "log"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn log_observer_name() {
+        assert_eq!(LogObserver::new().name(), "log");
+    }
+
+    #[test]
+    fn log_observer_all_events_no_panic() {
+        let obs = LogObserver::new();
+        obs.record_event(&ObserverEvent::AgentStart {
+            provider: "openrouter".into(),
+            model: "claude-sonnet".into(),
+        });
+        obs.record_event(&ObserverEvent::AgentEnd {
+            provider: "openrouter".into(),
+            model: "claude-sonnet".into(),
+            duration: Duration::from_millis(500),
+            tokens_used: Some(100),
+            cost_usd: Some(0.0015),
+        });
+        obs.record_event(&ObserverEvent::AgentEnd {
+            provider: "openrouter".into(),
+            model: "claude-sonnet".into(),
+            duration: Duration::ZERO,
+            tokens_used: None,
+            cost_usd: None,
+        });
+        obs.record_event(&ObserverEvent::LlmResponse {
+            provider: "openrouter".into(),
+            model: "claude-sonnet".into(),
+            duration: Duration::from_millis(150),
+            success: true,
+            error_message: None,
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+        });
+        obs.record_event(&ObserverEvent::LlmResponse {
+            provider: "openrouter".into(),
+            model: "claude-sonnet".into(),
+            duration: Duration::from_millis(200),
+            success: false,
+            error_message: Some("rate limited".into()),
+            input_tokens: None,
+            output_tokens: None,
+        });
+        obs.record_event(&ObserverEvent::ToolCall {
+            tool: "shell".into(),
+            duration: Duration::from_millis(10),
+            success: false,
+        });
+        obs.record_event(&ObserverEvent::ChannelMessage {
+            channel: "telegram".into(),
+            direction: "outbound".into(),
+        });
+        obs.record_event(&ObserverEvent::HeartbeatTick);
+        obs.record_event(&ObserverEvent::Error {
+            component: "provider".into(),
+            message: "timeout".into(),
+        });
+    }
+
+    #[test]
+    fn log_observer_all_metrics_no_panic() {
+        let obs = LogObserver::new();
+        obs.record_metric(&ObserverMetric::RequestLatency(Duration::from_secs(2)));
+        obs.record_metric(&ObserverMetric::TokensUsed(0));
+        obs.record_metric(&ObserverMetric::TokensUsed(u64::MAX));
+        obs.record_metric(&ObserverMetric::ActiveSessions(1));
+        obs.record_metric(&ObserverMetric::QueueDepth(999));
+    }
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,124 @@
+//! Observability subsystem for agent runtime telemetry.
+//!
+//! This module provides traits and implementations for recording events and
+//! metrics from the agent runtime. The modular design supports multiple backends
+//! (console logging, Prometheus, OpenTelemetry) via the [`Observer`] trait.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+pub mod log;
+pub mod traits;
+
+pub use log::LogObserver;
+pub use traits::{Observer, ObserverEvent, ObserverMetric};
+
+use std::sync::Arc;
+
+/// Composite observer that dispatches to multiple backends.
+///
+/// Useful for sending telemetry to both local logs and external systems
+/// (e.g., Prometheus + structured logging).
+pub struct CompositeObserver {
+    observers: Vec<Arc<dyn Observer>>,
+}
+
+impl CompositeObserver {
+    /// Create a composite observer from a list of observer implementations.
+    pub fn new(observers: Vec<Arc<dyn Observer>>) -> Self {
+        Self { observers }
+    }
+
+    /// Add an observer to the composite.
+    pub fn add(&mut self, observer: Arc<dyn Observer>) {
+        self.observers.push(observer);
+    }
+}
+
+impl Observer for CompositeObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        for observer in &self.observers {
+            observer.record_event(event);
+        }
+    }
+
+    fn record_metric(&self, metric: &ObserverMetric) {
+        for observer in &self.observers {
+            observer.record_metric(metric);
+        }
+    }
+
+    fn flush(&self) {
+        for observer in &self.observers {
+            observer.flush();
+        }
+    }
+
+    fn name(&self) -> &str {
+        "composite"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct CountingObserver {
+        events: Mutex<u64>,
+        metrics: Mutex<u64>,
+        flushes: Mutex<u64>,
+    }
+
+    impl Observer for CountingObserver {
+        fn record_event(&self, _event: &ObserverEvent) {
+            *self.events.lock().unwrap() += 1;
+        }
+
+        fn record_metric(&self, _metric: &ObserverMetric) {
+            *self.metrics.lock().unwrap() += 1;
+        }
+
+        fn flush(&self) {
+            *self.flushes.lock().unwrap() += 1;
+        }
+
+        fn name(&self) -> &str {
+            "counting"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[test]
+    fn composite_dispatches_to_all_backends() {
+        let obs1 = Arc::new(CountingObserver::default());
+        let obs2 = Arc::new(CountingObserver::default());
+
+        let composite = CompositeObserver::new(vec![obs1.clone(), obs2.clone()]);
+
+        composite.record_event(&ObserverEvent::HeartbeatTick);
+        composite.record_metric(&ObserverMetric::TokensUsed(100));
+        composite.flush();
+
+        assert_eq!(*obs1.events.lock().unwrap(), 1);
+        assert_eq!(*obs2.events.lock().unwrap(), 1);
+        assert_eq!(*obs1.metrics.lock().unwrap(), 1);
+        assert_eq!(*obs2.metrics.lock().unwrap(), 1);
+        assert_eq!(*obs1.flushes.lock().unwrap(), 1);
+        assert_eq!(*obs2.flushes.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn composite_name() {
+        let composite = CompositeObserver::new(vec![]);
+        assert_eq!(composite.name(), "composite");
+    }
+}

--- a/src/observability/traits.rs
+++ b/src/observability/traits.rs
@@ -1,0 +1,208 @@
+//! Observability traits and event types.
+//!
+//! This module defines the [`Observer`] trait and event/metric types for
+//! recording agent runtime telemetry. Implementations integrate with various
+//! backends (console logging, Prometheus, OpenTelemetry).
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+use std::time::Duration;
+
+/// Discrete events emitted by the agent runtime for observability.
+///
+/// Each variant represents a lifecycle event that observers can record,
+/// aggregate, or forward to external monitoring systems. Events carry
+/// just enough context for tracing and diagnostics without exposing
+/// sensitive prompt or response content.
+#[derive(Debug, Clone)]
+pub enum ObserverEvent {
+    /// The agent orchestration loop has started a new session.
+    AgentStart { provider: String, model: String },
+    /// A request is about to be sent to an LLM provider.
+    ///
+    /// This is emitted immediately before a provider call so observers can print
+    /// user-facing progress without leaking prompt contents.
+    LlmRequest {
+        provider: String,
+        model: String,
+        messages_count: usize,
+    },
+    /// Result of a single LLM provider call.
+    LlmResponse {
+        provider: String,
+        model: String,
+        duration: Duration,
+        success: bool,
+        error_message: Option<String>,
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+    },
+    /// The agent session has finished.
+    ///
+    /// Carries aggregate usage data (tokens, cost) when the provider reports it.
+    AgentEnd {
+        provider: String,
+        model: String,
+        duration: Duration,
+        tokens_used: Option<u64>,
+        cost_usd: Option<f64>,
+    },
+    /// A tool call is about to be executed.
+    ToolCallStart { tool: String },
+    /// A tool call has completed with a success/failure outcome.
+    ToolCall {
+        tool: String,
+        duration: Duration,
+        success: bool,
+    },
+    /// The agent produced a final answer for the current user message.
+    TurnComplete,
+    /// A message was sent or received through a channel.
+    ChannelMessage {
+        /// Channel name (e.g., `"telegram"`, `"discord"`).
+        channel: String,
+        /// `"inbound"` or `"outbound"`.
+        direction: String,
+    },
+    /// Periodic heartbeat tick from the runtime keep-alive loop.
+    HeartbeatTick,
+    /// An error occurred in a named component.
+    Error {
+        /// Subsystem where the error originated (e.g., `"provider"`, `"gateway"`).
+        component: String,
+        /// Human-readable error description. Must not contain secrets or tokens.
+        message: String,
+    },
+}
+
+/// Numeric metrics emitted by the agent runtime.
+///
+/// Observers can aggregate these into dashboards, alerts, or structured logs.
+/// Each variant carries a single scalar value with implicit units.
+#[derive(Debug, Clone)]
+pub enum ObserverMetric {
+    /// Time elapsed for a single LLM or tool request.
+    RequestLatency(Duration),
+    /// Number of tokens consumed by an LLM call.
+    TokensUsed(u64),
+    /// Current number of active concurrent sessions.
+    ActiveSessions(u64),
+    /// Current depth of the inbound message queue.
+    QueueDepth(u64),
+}
+
+/// Core observability trait for recording agent runtime telemetry.
+///
+/// Implement this trait to integrate with any monitoring backend (structured
+/// logging, Prometheus, OpenTelemetry, etc.). The agent runtime holds one or
+/// more `Observer` instances and calls [`record_event`](Observer::record_event)
+/// and [`record_metric`](Observer::record_metric) at key lifecycle points.
+///
+/// Implementations must be `Send + Sync + 'static` because the observer is
+/// shared across async tasks via `Arc`.
+pub trait Observer: Send + Sync + 'static {
+    /// Record a discrete lifecycle event.
+    ///
+    /// Called synchronously on the hot path; implementations should avoid
+    /// blocking I/O. Buffer events internally and flush asynchronously
+    /// when possible.
+    fn record_event(&self, event: &ObserverEvent);
+
+    /// Record a numeric metric sample.
+    ///
+    /// Called synchronously; same non-blocking guidance as
+    /// [`record_event`](Observer::record_event).
+    fn record_metric(&self, metric: &ObserverMetric);
+
+    /// Flush any buffered telemetry data to the backend.
+    ///
+    /// The runtime calls this during graceful shutdown. The default
+    /// implementation is a no-op, which is appropriate for backends
+    /// that write synchronously.
+    fn flush(&self) {}
+
+    /// Return the human-readable name of this observer backend.
+    ///
+    /// Used in logs and diagnostics (e.g., `"console"`, `"prometheus"`,
+    /// `"opentelemetry"`).
+    fn name(&self) -> &str;
+
+    /// Downcast to `Any` for backend-specific operations.
+    ///
+    /// Enables callers to access concrete observer types when needed
+    /// (e.g., retrieving a Prometheus registry handle for custom metrics).
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct DummyObserver {
+        events: Mutex<u64>,
+        metrics: Mutex<u64>,
+    }
+
+    impl Observer for DummyObserver {
+        fn record_event(&self, _event: &ObserverEvent) {
+            let mut guard = self.events.lock().unwrap();
+            *guard += 1;
+        }
+
+        fn record_metric(&self, _metric: &ObserverMetric) {
+            let mut guard = self.metrics.lock().unwrap();
+            *guard += 1;
+        }
+
+        fn name(&self) -> &str {
+            "dummy-observer"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[test]
+    fn observer_records_events_and_metrics() {
+        let observer = DummyObserver::default();
+
+        observer.record_event(&ObserverEvent::HeartbeatTick);
+        observer.record_event(&ObserverEvent::Error {
+            component: "test".into(),
+            message: "boom".into(),
+        });
+        observer.record_metric(&ObserverMetric::TokensUsed(42));
+
+        assert_eq!(*observer.events.lock().unwrap(), 2);
+        assert_eq!(*observer.metrics.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn observer_default_flush_and_as_any_work() {
+        let observer = DummyObserver::default();
+
+        observer.flush();
+        assert_eq!(observer.name(), "dummy-observer");
+        assert!(observer.as_any().downcast_ref::<DummyObserver>().is_some());
+    }
+
+    #[test]
+    fn observer_event_and_metric_are_cloneable() {
+        let event = ObserverEvent::ToolCall {
+            tool: "shell".into(),
+            duration: Duration::from_millis(10),
+            success: true,
+        };
+        let metric = ObserverMetric::RequestLatency(Duration::from_millis(8));
+
+        let cloned_event = event.clone();
+        let cloned_metric = metric.clone();
+
+        assert!(matches!(cloned_event, ObserverEvent::ToolCall { .. }));
+        assert!(matches!(cloned_metric, ObserverMetric::RequestLatency(_)));
+    }
+}

--- a/src/runtime/docker.rs
+++ b/src/runtime/docker.rs
@@ -1,0 +1,327 @@
+//! Docker runtime implementation.
+//!
+//! Provides lightweight container isolation for agent command execution.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+use super::traits::RuntimeAdapter;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Docker runtime configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DockerRuntimeConfig {
+    /// Docker image to use (e.g., "alpine:3.20").
+    #[serde(default = "default_docker_image")]
+    pub image: String,
+    /// Docker network mode (e.g., "none", "bridge", "host").
+    #[serde(default)]
+    pub network: String,
+    /// Memory limit in MB (optional).
+    #[serde(default)]
+    pub memory_limit_mb: Option<u64>,
+    /// CPU limit (e.g., 1.5 = 1.5 CPUs).
+    #[serde(default)]
+    pub cpu_limit: Option<f64>,
+    /// Mount the root filesystem as read-only.
+    #[serde(default)]
+    pub read_only_rootfs: bool,
+    /// Mount the workspace directory into the container.
+    #[serde(default = "default_true")]
+    pub mount_workspace: bool,
+    /// Allowed workspace root paths (if empty, any path is allowed).
+    #[serde(default)]
+    pub allowed_workspace_roots: Vec<String>,
+}
+
+fn default_docker_image() -> String {
+    "alpine:latest".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for DockerRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            image: default_docker_image(),
+            network: String::new(),
+            memory_limit_mb: None,
+            cpu_limit: None,
+            read_only_rootfs: false,
+            mount_workspace: true,
+            allowed_workspace_roots: Vec::new(),
+        }
+    }
+}
+
+/// Docker runtime with lightweight container isolation.
+#[derive(Debug, Clone)]
+pub struct DockerRuntime {
+    config: DockerRuntimeConfig,
+}
+
+impl DockerRuntime {
+    pub fn new(config: DockerRuntimeConfig) -> Self {
+        Self { config }
+    }
+
+    fn workspace_mount_path(&self, workspace_dir: &Path) -> Result<PathBuf> {
+        let resolved = workspace_dir
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_dir.to_path_buf());
+
+        if !resolved.is_absolute() {
+            anyhow::bail!(
+                "Docker runtime requires an absolute workspace path, got: {}",
+                resolved.display()
+            );
+        }
+
+        if resolved == Path::new("/") {
+            anyhow::bail!("Refusing to mount filesystem root (/) into docker runtime");
+        }
+
+        if self.config.allowed_workspace_roots.is_empty() {
+            return Ok(resolved);
+        }
+
+        let allowed = self.config.allowed_workspace_roots.iter().any(|root| {
+            let root_path = Path::new(root)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(root));
+            resolved.starts_with(root_path)
+        });
+
+        if !allowed {
+            anyhow::bail!(
+                "Workspace path {} is not in runtime.docker.allowed_workspace_roots",
+                resolved.display()
+            );
+        }
+
+        Ok(resolved)
+    }
+}
+
+impl RuntimeAdapter for DockerRuntime {
+    fn name(&self) -> &str {
+        "docker"
+    }
+
+    fn has_shell_access(&self) -> bool {
+        true
+    }
+
+    fn has_filesystem_access(&self) -> bool {
+        self.config.mount_workspace
+    }
+
+    fn storage_path(&self) -> PathBuf {
+        if self.config.mount_workspace {
+            PathBuf::from("/workspace/.rustyclaw")
+        } else {
+            PathBuf::from("/tmp/.rustyclaw")
+        }
+    }
+
+    fn supports_long_running(&self) -> bool {
+        false
+    }
+
+    fn memory_budget(&self) -> u64 {
+        self.config
+            .memory_limit_mb
+            .map_or(0, |mb| mb.saturating_mul(1024 * 1024))
+    }
+
+    fn build_shell_command(
+        &self,
+        command: &str,
+        workspace_dir: &Path,
+    ) -> anyhow::Result<tokio::process::Command> {
+        let mut process = tokio::process::Command::new("docker");
+        process
+            .arg("run")
+            .arg("--rm")
+            .arg("--init")
+            .arg("--interactive");
+
+        let network = self.config.network.trim();
+        if !network.is_empty() {
+            process.arg("--network").arg(network);
+        }
+
+        if let Some(memory_limit_mb) = self.config.memory_limit_mb.filter(|mb| *mb > 0) {
+            process.arg("--memory").arg(format!("{memory_limit_mb}m"));
+        }
+
+        if let Some(cpu_limit) = self.config.cpu_limit.filter(|cpus| *cpus > 0.0) {
+            process.arg("--cpus").arg(cpu_limit.to_string());
+        }
+
+        if self.config.read_only_rootfs {
+            process.arg("--read-only");
+        }
+
+        if self.config.mount_workspace {
+            let host_workspace = self.workspace_mount_path(workspace_dir).with_context(|| {
+                format!(
+                    "Failed to validate workspace mount path {}",
+                    workspace_dir.display()
+                )
+            })?;
+
+            process
+                .arg("--volume")
+                .arg(format!("{}:/workspace:rw", host_workspace.display()))
+                .arg("--workdir")
+                .arg("/workspace");
+        }
+
+        process
+            .arg(self.config.image.trim())
+            .arg("sh")
+            .arg("-c")
+            .arg(command);
+
+        Ok(process)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn docker_runtime_name() {
+        let runtime = DockerRuntime::new(DockerRuntimeConfig::default());
+        assert_eq!(runtime.name(), "docker");
+    }
+
+    #[test]
+    fn docker_runtime_memory_budget() {
+        let mut cfg = DockerRuntimeConfig::default();
+        cfg.memory_limit_mb = Some(256);
+        let runtime = DockerRuntime::new(cfg);
+        assert_eq!(runtime.memory_budget(), 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn docker_build_shell_command_includes_runtime_flags() {
+        let cfg = DockerRuntimeConfig {
+            image: "alpine:3.20".into(),
+            network: "none".into(),
+            memory_limit_mb: Some(128),
+            cpu_limit: Some(1.5),
+            read_only_rootfs: true,
+            mount_workspace: true,
+            allowed_workspace_roots: Vec::new(),
+        };
+        let runtime = DockerRuntime::new(cfg);
+
+        let workspace = std::env::temp_dir();
+        let command = runtime
+            .build_shell_command("echo hello", &workspace)
+            .unwrap();
+        let debug = format!("{command:?}");
+
+        assert!(debug.contains("docker"));
+        assert!(debug.contains("--memory"));
+        assert!(debug.contains("128m"));
+        assert!(debug.contains("--cpus"));
+        assert!(debug.contains("1.5"));
+        assert!(debug.contains("--workdir"));
+        assert!(debug.contains("echo hello"));
+    }
+
+    #[test]
+    fn docker_workspace_allowlist_blocks_outside_paths() {
+        let cfg = DockerRuntimeConfig {
+            allowed_workspace_roots: vec!["/tmp/allowed".into()],
+            ..DockerRuntimeConfig::default()
+        };
+        let runtime = DockerRuntime::new(cfg);
+
+        let outside = PathBuf::from("/tmp/blocked_workspace");
+        let result = runtime.build_shell_command("echo test", &outside);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn docker_build_shell_command_includes_network_flag() {
+        let cfg = DockerRuntimeConfig {
+            network: "none".into(),
+            ..DockerRuntimeConfig::default()
+        };
+        let runtime = DockerRuntime::new(cfg);
+        let workspace = std::env::temp_dir();
+        let cmd = runtime
+            .build_shell_command("echo hello", &workspace)
+            .unwrap();
+        let debug = format!("{cmd:?}");
+        assert!(
+            debug.contains("--network") && debug.contains("none"),
+            "must include --network none for isolation"
+        );
+    }
+
+    #[test]
+    fn docker_build_shell_command_includes_read_only_flag() {
+        let cfg = DockerRuntimeConfig {
+            read_only_rootfs: true,
+            ..DockerRuntimeConfig::default()
+        };
+        let runtime = DockerRuntime::new(cfg);
+        let workspace = std::env::temp_dir();
+        let cmd = runtime
+            .build_shell_command("echo hello", &workspace)
+            .unwrap();
+        let debug = format!("{cmd:?}");
+        assert!(
+            debug.contains("--read-only"),
+            "must include --read-only flag when read_only_rootfs is set"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn docker_refuses_root_mount() {
+        let cfg = DockerRuntimeConfig {
+            mount_workspace: true,
+            ..DockerRuntimeConfig::default()
+        };
+        let runtime = DockerRuntime::new(cfg);
+        let result = runtime.build_shell_command("echo test", Path::new("/"));
+        assert!(
+            result.is_err(),
+            "mounting filesystem root (/) must be refused"
+        );
+        let error_chain = format!("{:#}", result.unwrap_err());
+        assert!(
+            error_chain.contains("root"),
+            "expected root-mount error chain, got: {error_chain}"
+        );
+    }
+
+    #[test]
+    fn docker_no_memory_flag_when_not_configured() {
+        let cfg = DockerRuntimeConfig {
+            memory_limit_mb: None,
+            ..DockerRuntimeConfig::default()
+        };
+        let runtime = DockerRuntime::new(cfg);
+        let workspace = std::env::temp_dir();
+        let cmd = runtime
+            .build_shell_command("echo hello", &workspace)
+            .unwrap();
+        let debug = format!("{cmd:?}");
+        assert!(
+            !debug.contains("--memory"),
+            "should not include --memory when not configured"
+        );
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,0 +1,105 @@
+//! Runtime subsystem for platform abstraction.
+//!
+//! This module provides the [`RuntimeAdapter`] trait and implementations for
+//! different execution environments. The runtime abstraction allows RustyClaw
+//! to run on native systems, Docker containers, and (in future) serverless
+//! platforms with appropriate capability detection.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+pub mod docker;
+pub mod native;
+pub mod traits;
+
+pub use docker::{DockerRuntime, DockerRuntimeConfig};
+pub use native::NativeRuntime;
+pub use traits::RuntimeAdapter;
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Runtime kind: "native", "docker", etc.
+    #[serde(default = "default_runtime_kind")]
+    pub kind: String,
+    /// Docker-specific configuration.
+    #[serde(default)]
+    pub docker: DockerRuntimeConfig,
+}
+
+fn default_runtime_kind() -> String {
+    "native".to_string()
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            kind: default_runtime_kind(),
+            docker: DockerRuntimeConfig::default(),
+        }
+    }
+}
+
+/// Factory: create the right runtime from config
+pub fn create_runtime(config: &RuntimeConfig) -> anyhow::Result<Box<dyn RuntimeAdapter>> {
+    match config.kind.as_str() {
+        "native" => Ok(Box::new(NativeRuntime::new())),
+        "docker" => Ok(Box::new(DockerRuntime::new(config.docker.clone()))),
+        other if other.trim().is_empty() => {
+            anyhow::bail!("runtime.kind cannot be empty. Supported values: native, docker")
+        }
+        other => anyhow::bail!("Unknown runtime kind '{other}'. Supported values: native, docker"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factory_native() {
+        let cfg = RuntimeConfig {
+            kind: "native".into(),
+            ..RuntimeConfig::default()
+        };
+        let rt = create_runtime(&cfg).unwrap();
+        assert_eq!(rt.name(), "native");
+        assert!(rt.has_shell_access());
+    }
+
+    #[test]
+    fn factory_docker() {
+        let cfg = RuntimeConfig {
+            kind: "docker".into(),
+            ..RuntimeConfig::default()
+        };
+        let rt = create_runtime(&cfg).unwrap();
+        assert_eq!(rt.name(), "docker");
+        assert!(rt.has_shell_access());
+    }
+
+    #[test]
+    fn factory_unknown_errors() {
+        let cfg = RuntimeConfig {
+            kind: "wasm-edge-unknown".into(),
+            ..RuntimeConfig::default()
+        };
+        match create_runtime(&cfg) {
+            Err(err) => assert!(err.to_string().contains("Unknown runtime kind")),
+            Ok(_) => panic!("unknown runtime should error"),
+        }
+    }
+
+    #[test]
+    fn factory_empty_errors() {
+        let cfg = RuntimeConfig {
+            kind: String::new(),
+            ..RuntimeConfig::default()
+        };
+        match create_runtime(&cfg) {
+            Err(err) => assert!(err.to_string().contains("cannot be empty")),
+            Ok(_) => panic!("empty runtime should error"),
+        }
+    }
+}

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -1,0 +1,114 @@
+//! Native runtime implementation.
+//!
+//! Full-access runtime for Mac/Linux/Windows with shell, filesystem, and
+//! long-running process support.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+use super::traits::RuntimeAdapter;
+use std::path::{Path, PathBuf};
+
+/// Native runtime — full access, runs on Mac/Linux/Windows/Raspberry Pi
+pub struct NativeRuntime;
+
+impl NativeRuntime {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NativeRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeAdapter for NativeRuntime {
+    fn name(&self) -> &str {
+        "native"
+    }
+
+    fn has_shell_access(&self) -> bool {
+        true
+    }
+
+    fn has_filesystem_access(&self) -> bool {
+        true
+    }
+
+    fn storage_path(&self) -> PathBuf {
+        directories::UserDirs::new().map_or_else(
+            || PathBuf::from(".rustyclaw"),
+            |u| u.home_dir().join(".rustyclaw"),
+        )
+    }
+
+    fn supports_long_running(&self) -> bool {
+        true
+    }
+
+    fn build_shell_command(
+        &self,
+        command: &str,
+        workspace_dir: &Path,
+    ) -> anyhow::Result<tokio::process::Command> {
+        #[cfg(unix)]
+        {
+            let mut process = tokio::process::Command::new("sh");
+            process.arg("-c").arg(command).current_dir(workspace_dir);
+            Ok(process)
+        }
+        #[cfg(windows)]
+        {
+            let mut process = tokio::process::Command::new("cmd");
+            process.arg("/C").arg(command).current_dir(workspace_dir);
+            Ok(process)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_name() {
+        assert_eq!(NativeRuntime::new().name(), "native");
+    }
+
+    #[test]
+    fn native_has_shell_access() {
+        assert!(NativeRuntime::new().has_shell_access());
+    }
+
+    #[test]
+    fn native_has_filesystem_access() {
+        assert!(NativeRuntime::new().has_filesystem_access());
+    }
+
+    #[test]
+    fn native_supports_long_running() {
+        assert!(NativeRuntime::new().supports_long_running());
+    }
+
+    #[test]
+    fn native_memory_budget_unlimited() {
+        assert_eq!(NativeRuntime::new().memory_budget(), 0);
+    }
+
+    #[test]
+    fn native_storage_path_contains_rustyclaw() {
+        let path = NativeRuntime::new().storage_path();
+        assert!(path.to_string_lossy().contains("rustyclaw"));
+    }
+
+    #[test]
+    fn native_builds_shell_command() {
+        let cwd = std::env::temp_dir();
+        let command = NativeRuntime::new()
+            .build_shell_command("echo hello", &cwd)
+            .unwrap();
+        let debug = format!("{command:?}");
+        assert!(debug.contains("echo hello"));
+    }
+}

--- a/src/runtime/traits.rs
+++ b/src/runtime/traits.rs
@@ -1,0 +1,151 @@
+//! Runtime adapter trait for platform abstraction.
+//!
+//! This module defines the [`RuntimeAdapter`] trait which abstracts platform
+//! differences for agent execution. Implementations allow RustyClaw to run on
+//! different environments (native, Docker, serverless) with appropriate
+//! capability detection.
+//!
+//! Adapted from ZeroClaw (MIT OR Apache-2.0 licensed).
+
+use std::path::{Path, PathBuf};
+
+/// Runtime adapter that abstracts platform differences for the agent.
+///
+/// Implement this trait to port the agent to a new execution environment.
+/// The adapter declares platform capabilities (shell access, filesystem,
+/// long-running processes) and provides platform-specific implementations
+/// for operations like spawning shell commands. The orchestration loop
+/// queries these capabilities to adapt its behavior—for example, disabling
+/// tool execution on runtimes without shell access.
+///
+/// Implementations must be `Send + Sync` because the adapter is shared
+/// across async tasks on the Tokio runtime.
+pub trait RuntimeAdapter: Send + Sync {
+    /// Return the human-readable name of this runtime environment.
+    ///
+    /// Used in logs and diagnostics (e.g., `"native"`, `"docker"`,
+    /// `"cloudflare-workers"`).
+    fn name(&self) -> &str;
+
+    /// Report whether this runtime supports shell command execution.
+    ///
+    /// When `false`, the agent disables shell-based tools. Serverless and
+    /// edge runtimes typically return `false`.
+    fn has_shell_access(&self) -> bool;
+
+    /// Report whether this runtime supports filesystem read/write.
+    ///
+    /// When `false`, the agent disables file-based tools and falls back to
+    /// in-memory storage.
+    fn has_filesystem_access(&self) -> bool;
+
+    /// Return the base directory for persistent storage on this runtime.
+    ///
+    /// Memory backends, logs, and other artifacts are stored under this path.
+    /// Implementations should return a platform-appropriate writable directory.
+    fn storage_path(&self) -> PathBuf;
+
+    /// Report whether this runtime supports long-running background processes.
+    ///
+    /// When `true`, the agent may start the gateway server, heartbeat loop,
+    /// and other persistent tasks. Serverless runtimes with short execution
+    /// limits should return `false`.
+    fn supports_long_running(&self) -> bool;
+
+    /// Return the maximum memory budget in bytes for this runtime.
+    ///
+    /// A value of `0` (the default) indicates no limit. Constrained
+    /// environments (embedded, serverless) should return their actual
+    /// memory ceiling so the agent can adapt buffer sizes and caching.
+    fn memory_budget(&self) -> u64 {
+        0
+    }
+
+    /// Build a shell command process configured for this runtime.
+    ///
+    /// Constructs a [`tokio::process::Command`] that will execute `command`
+    /// with `workspace_dir` as the working directory. Implementations may
+    /// prepend sandbox wrappers, set environment variables, or redirect
+    /// I/O as appropriate for the platform.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the runtime does not support shell access or if
+    /// the command cannot be constructed (e.g., missing shell binary).
+    fn build_shell_command(
+        &self,
+        command: &str,
+        workspace_dir: &Path,
+    ) -> anyhow::Result<tokio::process::Command>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyRuntime;
+
+    impl RuntimeAdapter for DummyRuntime {
+        fn name(&self) -> &str {
+            "dummy-runtime"
+        }
+
+        fn has_shell_access(&self) -> bool {
+            true
+        }
+
+        fn has_filesystem_access(&self) -> bool {
+            true
+        }
+
+        fn storage_path(&self) -> PathBuf {
+            PathBuf::from("/tmp/dummy-runtime")
+        }
+
+        fn supports_long_running(&self) -> bool {
+            true
+        }
+
+        fn build_shell_command(
+            &self,
+            command: &str,
+            workspace_dir: &Path,
+        ) -> anyhow::Result<tokio::process::Command> {
+            let mut cmd = tokio::process::Command::new("sh");
+            cmd.arg("-c").arg(command);
+            cmd.current_dir(workspace_dir);
+            Ok(cmd)
+        }
+    }
+
+    #[test]
+    fn default_memory_budget_is_zero() {
+        let runtime = DummyRuntime;
+        assert_eq!(runtime.memory_budget(), 0);
+    }
+
+    #[test]
+    fn runtime_reports_capabilities() {
+        let runtime = DummyRuntime;
+
+        assert_eq!(runtime.name(), "dummy-runtime");
+        assert!(runtime.has_shell_access());
+        assert!(runtime.has_filesystem_access());
+        assert!(runtime.supports_long_running());
+        assert_eq!(runtime.storage_path(), PathBuf::from("/tmp/dummy-runtime"));
+    }
+
+    #[tokio::test]
+    async fn build_shell_command_executes() {
+        let runtime = DummyRuntime;
+        let mut cmd = runtime
+            .build_shell_command("echo hello-runtime", Path::new("."))
+            .unwrap();
+
+        let output = cmd.output().await.unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success());
+        assert!(stdout.contains("hello-runtime"));
+    }
+}


### PR DESCRIPTION
## Summary

Import platform abstraction and telemetry modules from [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw) (MIT OR Apache-2.0 licensed).

## Changes

### Runtime Subsystem (`src/runtime/`)

- **RuntimeAdapter trait**: Clean abstraction for platform differences
- **NativeRuntime**: Mac/Linux/Windows with full shell and filesystem access
- **DockerRuntime**: Container isolation with configurable:
  - Network isolation
  - Memory/CPU limits
  - Read-only rootfs
  - Workspace mount validation and allowlisting

### Observability Subsystem (`src/observability/`)

- **Observer trait**: Record events and metrics from agent runtime
- **ObserverEvent**: Lifecycle events (agent start/end, tool calls, errors)
- **ObserverMetric**: Numeric metrics (latency, tokens, sessions)
- **LogObserver**: Zero-dep implementation using `tracing`
- **CompositeObserver**: Dispatch to multiple backends

### Dependencies

- Added: `directories = "6.0"`

## Testing

Includes unit tests for all modules. Needs cargo check on a machine with Rust toolchain.

## Attribution

ZeroClaw: https://github.com/zeroclaw-labs/zeroclaw
License: MIT OR Apache-2.0