### PR TITLE
feat(observability): Wire Observer into gateway runtime

### DIFF
--- a/crates/rustyclaw-cli/src/bin/rustyclaw-gateway.rs
+++ b/crates/rustyclaw-cli/src/bin/rustyclaw-gateway.rs
@@ -335,6 +335,7 @@ async fn main() -> Result<()> {
             shared_skills,
             None,
             None,
+            None, // observer
             cancel,
         )
         .await

--- a/crates/rustyclaw-cli/src/main.rs
+++ b/crates/rustyclaw-cli/src/main.rs
@@ -1099,6 +1099,7 @@ async fn main() -> Result<()> {
                         shared_skills,
                         None,
                         None,
+                        None, // observer
                         cancel,
                     )
                     .await?;


### PR DESCRIPTION
Integrates the Observer trait into the gateway's request lifecycle.

## Changes

- Add `SharedObserver` type alias and optional parameter to `run_gateway`
- Thread observer through `handle_connection` → `dispatch_text_message`
- Record events at key lifecycle points:
  - **LlmRequest** — before provider calls (provider, model, message count)
  - **LlmResponse** — after calls (duration, success, error message)
  - **ToolCallStart** — before each tool execution
  - **ToolCall** — after (duration, success)

## Usage

Call sites currently pass `None` for the observer. To enable observability:

```rust
use rustyclaw_core::observability::{LogObserver, Observer};
use std::sync::Arc;

let observer: Arc<dyn Observer> = Arc::new(LogObserver);
run_gateway(..., Some(observer), cancel).await?;
```

## Next Steps

- Wire `LogObserver` by default when a config flag is set
- Extract token counts from provider responses
- Add `ObserverMetric` recording (latencies, queue depth)