### PR TITLE
fix(tui): Extract just the name from SOUL.md header

### DIFF
--- a/crates/rustyclaw-tui/src/app/app.rs
+++ b/crates/rustyclaw-tui/src/app/app.rs
@@ -217,15 +217,8 @@ impl App {
         let (user_tx, user_rx) = sync_mpsc::channel::<UserInput>();
 
         // ── Gather static info for the component ────────────────────────
-        let soul_name = self
-            .soul_manager
-            .get_content()
-            .and_then(|c: &str| {
-                c.lines()
-                    .find(|l: &&str| l.starts_with("# "))
-                    .map(|l: &str| l.trim_start_matches("# ").to_string())
-            })
-            .unwrap_or_else(|| "RustyClaw".to_string());
+        // Use the configured agent_name — no need to parse SOUL.md
+        let soul_name = self.config.agent_name.clone();
 
         let provider = self
             .config


### PR DESCRIPTION
Parse headers like 'SOUL.md – Jadzia, The Joined Explorer' to extract only 'Jadzia' for the chat bubble label. The full description can still appear in the status bar.

- Split on ' – ' or ' - ' to get name after 'SOUL.md'
- Take only the part before comma for short name
- Falls back to full header if no separator found

This was meant to be part of PR #89 but the PR was merged before this commit synced.