### PR TITLE
feat: Integrate oxidized-skills for skill security auditing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "accessory"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +959,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -3563,6 +3583,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "oxidized-skills"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6edb03595502b5af6d54e1c95ae10102e3178d33596decd1d1d317471577d0"
+dependencies = [
+ "chrono",
+ "clap",
+ "colored",
+ "rayon",
+ "regex",
+ "serde",
+ "serde-sarif",
+ "serde_json",
+ "tempfile",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,6 +4265,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4896,6 +4955,7 @@ dependencies = [
  "libc",
  "matrix-sdk",
  "openssl-sys",
+ "oxidized-skills",
  "qrcode",
  "rand 0.10.0",
  "regex",
@@ -4911,7 +4971,7 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "ssh-key",
- "strum",
+ "strum 0.28.0",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
@@ -4957,7 +5017,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "smol",
- "strum",
+ "strum 0.28.0",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -4998,6 +5058,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bec29dddcfe60f92f3c0d422707b8b56473983ef0481df8d5236ed3ab8fdf24"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3d87f1df246a9b7e2bfd1f4ee5f88e48b11ef9cfc62e63f0dead255b1a6f5f"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+ "uriparse",
 ]
 
 [[package]]
@@ -5149,6 +5236,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-sarif"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a053c46f18a8043570d4e32fefc4c6377f82bf29ec310a33e93f273048e3b0be"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "typed-builder 0.21.2",
 ]
 
 [[package]]
@@ -5572,11 +5679,29 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6138,11 +6263,31 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro 0.21.2",
+]
+
+[[package]]
+name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.23.2",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6289,6 +6434,16 @@ dependencies = [
  "http",
  "httparse",
  "log",
+]
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
 ]
 
 [[package]]
@@ -6494,7 +6649,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
- "typed-builder",
+ "typed-builder 0.23.2",
  "wa-rs-appstate",
  "wa-rs-binary",
  "wa-rs-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ base64 = "0.22"
 regex = "1.10"
 aho-corasick = "1.1"
 ipnetwork = "0.21"
+oxidized-skills = "0.3"
 
 # HTTP date parsing (for Set-Cookie expires)
 httpdate = "1.0"

--- a/crates/rustyclaw-core/Cargo.toml
+++ b/crates/rustyclaw-core/Cargo.toml
@@ -67,6 +67,7 @@ bincode.workspace = true
 base64.workspace = true
 regex.workspace = true
 aho-corasick.workspace = true
+oxidized-skills.workspace = true
 ipnetwork.workspace = true
 httpdate.workspace = true
 colored.workspace = true

--- a/crates/rustyclaw-core/src/lib.rs
+++ b/crates/rustyclaw-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod runtime;
 pub mod sandbox;
 pub mod secrets;
 pub mod security;
+pub mod skill_audit;
 pub mod sessions;
 pub mod skills;
 pub mod soul;

--- a/crates/rustyclaw-core/src/skill_audit.rs
+++ b/crates/rustyclaw-core/src/skill_audit.rs
@@ -1,0 +1,242 @@
+//! Skill Security Auditing via oxidized-skills
+//!
+//! Integrates the `oxidized-skills` crate to scan skill directories for:
+//! - Dangerous bash patterns (RCE, credential exfiltration, reverse shells)
+//! - Prompt injection attempts
+//! - Exposed secrets
+//! - Unsafe package installations
+//! - Frontmatter validation issues
+//!
+//! Can be used to audit skills at load time or on-demand.
+
+use oxidized_skills::{audit, config::Config, finding::AuditReport, output};
+use std::path::Path;
+use tracing::{debug, warn};
+
+/// Result of auditing a skill directory.
+#[derive(Debug)]
+pub struct SkillAuditResult {
+    /// Name of the skill that was audited
+    pub skill_name: String,
+    /// Path to the skill directory
+    pub skill_path: String,
+    /// Whether the audit passed (no errors)
+    pub passed: bool,
+    /// Security score (0-100)
+    pub score: u8,
+    /// Letter grade (A-F)
+    pub grade: char,
+    /// Number of errors found
+    pub error_count: usize,
+    /// Number of warnings found
+    pub warning_count: usize,
+    /// Summary of findings (human-readable)
+    pub summary: String,
+    /// Full report for detailed inspection
+    pub report: Option<AuditReport>,
+}
+
+impl SkillAuditResult {
+    /// Check if the skill should be blocked from loading based on score
+    pub fn should_block(&self, min_score: u8) -> bool {
+        self.score < min_score || self.error_count > 0
+    }
+
+    /// Get a one-line status for logging
+    pub fn status_line(&self) -> String {
+        if self.passed {
+            format!(
+                "✓ {} — Score: {}/100 ({})",
+                self.skill_name, self.score, self.grade
+            )
+        } else {
+            format!(
+                "✗ {} — Score: {}/100 ({}) — {} errors, {} warnings",
+                self.skill_name, self.score, self.grade, self.error_count, self.warning_count
+            )
+        }
+    }
+}
+
+/// Skill security auditor using oxidized-skills.
+pub struct SkillAuditor {
+    config: Config,
+    /// Minimum score required to pass (0-100)
+    pub min_score: u8,
+    /// Whether to block loading of skills that fail audit
+    pub block_on_failure: bool,
+}
+
+impl Default for SkillAuditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SkillAuditor {
+    /// Create a new auditor with default configuration.
+    pub fn new() -> Self {
+        let config = Config::load(None).unwrap_or_default();
+        Self {
+            config,
+            min_score: 70, // Default: require at least a C grade
+            block_on_failure: false,
+        }
+    }
+
+    /// Create an auditor with custom minimum score.
+    pub fn with_min_score(mut self, score: u8) -> Self {
+        self.min_score = score.min(100);
+        self
+    }
+
+    /// Set whether to block loading of failing skills.
+    pub fn with_blocking(mut self, block: bool) -> Self {
+        self.block_on_failure = block;
+        self
+    }
+
+    /// Load configuration from a custom path.
+    pub fn with_config_path(mut self, path: &Path) -> Self {
+        if let Ok(config) = Config::load(Some(path)) {
+            self.config = config;
+        }
+        self
+    }
+
+    /// Audit a single skill directory.
+    pub fn audit_skill(&self, skill_path: &Path, skill_name: &str) -> SkillAuditResult {
+        debug!("Auditing skill: {} at {}", skill_name, skill_path.display());
+
+        let report = audit::run_audit(skill_path, &self.config);
+
+        let score = report.security_score;
+        let grade = grade_to_char(&report.security_grade);
+        let error_count = report
+            .findings
+            .iter()
+            .filter(|f| f.severity == oxidized_skills::finding::Severity::Error)
+            .count();
+        let warning_count = report
+            .findings
+            .iter()
+            .filter(|f| f.severity == oxidized_skills::finding::Severity::Warning)
+            .count();
+
+        let summary = if report.passed {
+            format!("Audit passed with score {}/100", score)
+        } else {
+            let findings: Vec<String> = report
+                .findings
+                .iter()
+                .take(5)
+                .map(|f| format!("  - [{}] {}: {}", f.rule_id, f.scanner, f.message))
+                .collect();
+            format!(
+                "Audit failed with {} errors, {} warnings:\n{}{}",
+                error_count,
+                warning_count,
+                findings.join("\n"),
+                if report.findings.len() > 5 {
+                    format!("\n  ... and {} more", report.findings.len() - 5)
+                } else {
+                    String::new()
+                }
+            )
+        };
+
+        if !report.passed {
+            warn!(
+                "Skill {} failed security audit: {} errors, {} warnings (score: {})",
+                skill_name, error_count, warning_count, score
+            );
+        }
+
+        SkillAuditResult {
+            skill_name: skill_name.to_string(),
+            skill_path: skill_path.display().to_string(),
+            passed: report.passed,
+            score,
+            grade,
+            error_count,
+            warning_count,
+            summary,
+            report: Some(report),
+        }
+    }
+
+    /// Audit multiple skill directories.
+    pub fn audit_skills(&self, skills: &[(impl AsRef<Path>, &str)]) -> Vec<SkillAuditResult> {
+        skills
+            .iter()
+            .map(|(path, name)| self.audit_skill(path.as_ref(), name))
+            .collect()
+    }
+
+    /// Get a formatted report for a skill audit.
+    pub fn format_report(&self, result: &SkillAuditResult) -> String {
+        if let Some(ref report) = result.report {
+            output::format_report(report, &output::OutputFormat::Pretty)
+        } else {
+            result.summary.clone()
+        }
+    }
+
+    /// Get JSON output for a skill audit.
+    pub fn format_report_json(&self, result: &SkillAuditResult) -> String {
+        if let Some(ref report) = result.report {
+            output::format_report(report, &output::OutputFormat::Json)
+        } else {
+            serde_json::json!({
+                "skill": result.skill_name,
+                "passed": result.passed,
+                "score": result.score,
+                "grade": result.grade.to_string(),
+            })
+            .to_string()
+        }
+    }
+}
+
+/// Convert SecurityGrade enum to a char.
+fn grade_to_char(grade: &oxidized_skills::finding::SecurityGrade) -> char {
+    use oxidized_skills::finding::SecurityGrade;
+    match grade {
+        SecurityGrade::A => 'A',
+        SecurityGrade::B => 'B',
+        SecurityGrade::C => 'C',
+        SecurityGrade::D => 'D',
+        SecurityGrade::F => 'F',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auditor_default() {
+        let auditor = SkillAuditor::new();
+        assert_eq!(auditor.min_score, 70);
+        assert!(!auditor.block_on_failure);
+    }
+
+    #[test]
+    fn test_should_block() {
+        let result = SkillAuditResult {
+            skill_name: "test".to_string(),
+            skill_path: "/tmp/test".to_string(),
+            passed: false,
+            score: 50,
+            grade: 'F',
+            error_count: 2,
+            warning_count: 1,
+            summary: "Failed".to_string(),
+            report: None,
+        };
+
+        assert!(result.should_block(70));
+        assert!(result.should_block(51));
+        assert!(!result.should_block(50)); // Still blocked due to error_count > 0
+    }
+}


### PR DESCRIPTION
## Summary

Integrates the [oxidized-skills](https://crates.io/crates/oxidized-skills) crate (v0.3) to scan skill directories for security vulnerabilities at load time.

## What Gets Scanned

| Scanner | Coverage |
|---------|----------|
| Bash patterns | 19 rules across 8 categories (RCE, credential exfiltration, reverse shells, privilege escalation, etc.) |
| TypeScript/JS | 10 rules (eval, child_process, raw sockets, outbound HTTP) |
| Prompt injection | 19 patterns (instruction override, jailbreak, data exfiltration) |
| Frontmatter | 16 rules (SKILL.md structure, XML injection, field limits) |
| Package install | 7 rules (unpinned versions, unapproved registries) |
| Secrets | gitleaks wrapper (if installed) |
| Shell linting | shellcheck wrapper (if installed) |

## New API

```rust
use rustyclaw_core::skill_audit::SkillAuditor;

let auditor = SkillAuditor::new()
    .with_min_score(80)      // Require B grade or higher
    .with_blocking(true);    // Block loading of failing skills

let result = auditor.audit_skill(Path::new("./my-skill"), "my-skill");

println!("{}", result.status_line());
// ✓ my-skill — Score: 95/100 (A)
// or
// ✗ my-skill — Score: 45/100 (F) — 3 errors, 2 warnings

if result.should_block(auditor.min_score) {
    eprintln!("Skill blocked:\n{}", result.summary);
}
```

## Output Formats

- `format_report()` — Pretty terminal output
- `format_report_json()` — JSON for tooling
- SARIF support via oxidized-skills for CI/CD integration

## Next Steps

- [ ] Wire into `SkillManager::load_skills()` with config option
- [ ] Add `rustyclaw skills audit <path>` CLI command
- [ ] Add GitHub Action integration example

## References

- [oxidized-skills on crates.io](https://crates.io/crates/oxidized-skills)
- [oxidized-skills docs](https://docs.rs/oxidized-skills)
- [GitHub repo](https://github.com/jbovet/oxidized-skills)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rexlunae/rustyclaw/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
