### PR TITLE
feat(core): genai-based provider registry (Issue #176)

### DIFF
--- a/crates/rustyclaw-core/Cargo.toml
+++ b/crates/rustyclaw-core/Cargo.toml
@@ -104,6 +104,7 @@ sha2 = { version = "0.10", optional = true }
 
 # QR code generation (optional)
 image = { version = "0.25", default-features = false, features = ["png"], optional = true }
+genai = "0.5.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/rustyclaw-core/src/genai_bridge.rs
+++ b/crates/rustyclaw-core/src/genai_bridge.rs
@@ -40,10 +40,7 @@ pub fn genai_to_rc_response(resp: &ChatResponse) -> ModelResponse {
     let mut result = ModelResponse::default();
 
     // Extract text content using the API
-    if let Some(ref content) = resp.content {
-        result.text = content.joined_texts().unwrap_or_default();
-    }
-    }
+    result.text = resp.content.joined_texts().unwrap_or_default();
 
     // Extract tool calls using the method
     let tool_calls = resp.tool_calls();

--- a/crates/rustyclaw-core/src/genai_bridge.rs
+++ b/crates/rustyclaw-core/src/genai_bridge.rs
@@ -7,21 +7,107 @@
 use crate::gateway::protocol::types::{ChatMessage as RcChatMessage, ModelResponse, ParsedToolCall};
 use genai::chat::{
     ChatMessage as GenaiChatMessage, ChatResponse, ChatStreamEvent, MessageContent, StreamEnd, Tool,
+    ToolCall, ToolResponse,
 };
 
 // ── Message Conversions ─────────────────────────────────────────────────────
 
+/// Convert a JSON tool-calls array (OpenAI format) to a `Vec<genai::chat::ToolCall>`.
+///
+/// Handles the OpenAI / OpenAI-compatible format:
+/// ```json
+/// [{ "id": "...", "type": "function", "function": { "name": "...", "arguments": "{...}" } }]
+/// ```
+/// `arguments` may be a JSON-encoded string **or** a JSON object — both are normalised to
+/// a `serde_json::Value`.
+fn json_to_genai_tool_calls(tool_calls_json: &serde_json::Value) -> Vec<ToolCall> {
+    let array = match tool_calls_json.as_array() {
+        Some(a) => a,
+        None => return vec![],
+    };
+    array
+        .iter()
+        .filter_map(|tc| {
+            // OpenAI format: { "id": "...", "function": { "name": "...", "arguments": "..." } }
+            let call_id = tc
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let (fn_name, fn_arguments) = if let Some(func) = tc.get("function") {
+                let name = func
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // `arguments` may be a pre-serialised JSON string or already an object.
+                let raw = func
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let parsed = if let Some(s) = raw.as_str() {
+                    serde_json::from_str(s).unwrap_or(serde_json::Value::Null)
+                } else {
+                    raw
+                };
+                (name, parsed)
+            } else {
+                // Flat format: { "name": "...", "arguments": { … } }
+                let name = tc
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = tc
+                    .get("arguments")
+                    .or_else(|| tc.get("parameters"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                (name, args)
+            };
+            Some(ToolCall {
+                call_id,
+                fn_name,
+                fn_arguments,
+                thought_signatures: None,
+            })
+        })
+        .collect()
+}
+
 /// Convert RustyClaw ChatMessage to genai ChatMessage.
+///
+/// Handles four roles:
+/// - `system` → `GenaiChatMessage::system`
+/// - `user`   → `GenaiChatMessage::user`
+/// - `assistant` → `GenaiChatMessage::assistant` **or** `assistant_tool_calls_with_thoughts`
+///   when `tool_calls` is present.
+/// - `tool` (tool result) → `GenaiChatMessage::user(ToolResponse { call_id, content })`
 pub fn rc_to_genai_message(msg: &RcChatMessage) -> GenaiChatMessage {
     match msg.role.as_str() {
         "system" => GenaiChatMessage::system(&msg.content),
         "user" => GenaiChatMessage::user(&msg.content),
-        "assistant" => GenaiChatMessage::assistant(&msg.content),
-        // For tool results, genai uses a different structure
+        "assistant" => {
+            // If the message carries tool calls, represent them properly.
+            if let Some(tc_json) = &msg.tool_calls {
+                let tool_calls = json_to_genai_tool_calls(tc_json);
+                if !tool_calls.is_empty() {
+                    return GenaiChatMessage::assistant_tool_calls_with_thoughts(
+                        tool_calls,
+                        vec![],
+                    );
+                }
+            }
+            GenaiChatMessage::assistant(&msg.content)
+        }
+        // Tool result: genai uses a ToolResponse carried inside a user message.
         "tool" => {
-            // Tool messages in RustyClaw have tool_call_id in a specific format
-            // For now, pass as user message (genai handles tool results differently)
-            GenaiChatMessage::user(&msg.content)
+            let call_id = msg.tool_call_id.clone().unwrap_or_default();
+            let tr = ToolResponse {
+                call_id,
+                content: msg.content.clone(),
+            };
+            GenaiChatMessage::user(tr)
         }
         _ => GenaiChatMessage::user(&msg.content),
     }
@@ -230,5 +316,65 @@ mod tests {
     fn test_extract_text_content_single() {
         let content = MessageContent::from_text("Hello world");
         assert_eq!(extract_text_content(&content), "Hello world");
+    }
+
+    #[test]
+    fn test_rc_to_genai_tool_result_message() {
+        let msg = RcChatMessage {
+            role: "tool".to_string(),
+            content: "42°C".to_string(),
+            tool_call_id: Some("call_abc".to_string()),
+            ..Default::default()
+        };
+        // Should not panic; genai encodes this as a user message carrying a ToolResponse.
+        let _genai_msg = rc_to_genai_message(&msg);
+    }
+
+    #[test]
+    fn test_rc_to_genai_assistant_with_tool_calls() {
+        use serde_json::json;
+        let tool_calls_json = json!([{
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": "{\"city\": \"London\"}"
+            }
+        }]);
+        let msg = RcChatMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            tool_calls: Some(tool_calls_json),
+            ..Default::default()
+        };
+        // Should use assistant_tool_calls_with_thoughts, not assistant("").
+        let _genai_msg = rc_to_genai_message(&msg);
+    }
+
+    #[test]
+    fn test_json_to_genai_tool_calls_openai_format() {
+        use serde_json::json;
+        let tc_json = json!([{
+            "id": "call_xyz",
+            "type": "function",
+            "function": {
+                "name": "search",
+                "arguments": "{\"query\": \"Rust\"}"
+            }
+        }]);
+        let calls = json_to_genai_tool_calls(&tc_json);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].call_id, "call_xyz");
+        assert_eq!(calls[0].fn_name, "search");
+        assert_eq!(calls[0].fn_arguments["query"], "Rust");
+    }
+
+    #[test]
+    fn test_json_to_genai_tool_calls_empty() {
+        use serde_json::json;
+        let calls = json_to_genai_tool_calls(&json!([]));
+        assert!(calls.is_empty());
+        let calls = json_to_genai_tool_calls(&json!(null));
+        assert!(calls.is_empty());
     }
 }

--- a/crates/rustyclaw-core/src/genai_bridge.rs
+++ b/crates/rustyclaw-core/src/genai_bridge.rs
@@ -1,0 +1,182 @@
+//! Type conversions between genai and RustyClaw gateway types.
+//!
+//! This module bridges the genai crate's types with RustyClaw's internal
+//! protocol types, allowing gradual migration from hand-rolled provider
+//! code to the genai abstraction.
+
+use crate::gateway::protocol::types::{ChatMessage as RcChatMessage, ModelResponse, ParsedToolCall};
+use genai::chat::{
+    ChatMessage as GenaiChatMessage, ChatResponse, ChatStreamEvent, MessageContent,
+    StreamEnd,
+};
+
+// ── Message Conversions ─────────────────────────────────────────────────────
+
+/// Convert RustyClaw ChatMessage to genai ChatMessage.
+pub fn rc_to_genai_message(msg: &RcChatMessage) -> GenaiChatMessage {
+    match msg.role.as_str() {
+        "system" => GenaiChatMessage::system(&msg.content),
+        "user" => GenaiChatMessage::user(&msg.content),
+        "assistant" => GenaiChatMessage::assistant(&msg.content),
+        // For tool results, genai uses a different structure
+        "tool" => {
+            // Tool messages in RustyClaw have tool_call_id in a specific format
+            // For now, pass as user message (genai handles tool results differently)
+            GenaiChatMessage::user(&msg.content)
+        }
+        _ => GenaiChatMessage::user(&msg.content),
+    }
+}
+
+/// Convert a slice of RustyClaw messages to genai messages.
+pub fn rc_to_genai_messages(messages: &[RcChatMessage]) -> Vec<GenaiChatMessage> {
+    messages.iter().map(rc_to_genai_message).collect()
+}
+
+// ── Response Conversions ────────────────────────────────────────────────────
+
+/// Convert genai ChatResponse to RustyClaw ModelResponse.
+pub fn genai_to_rc_response(resp: &ChatResponse) -> ModelResponse {
+    let mut result = ModelResponse::default();
+
+    // Extract text content using the API
+    if let Some(text) = resp.first_text() {
+        result.text = text.to_string();
+    }
+
+    // Extract tool calls using the method
+    let tool_calls = resp.tool_calls();
+    result.tool_calls = tool_calls
+        .into_iter()
+        .map(|tc| ParsedToolCall {
+            id: tc.call_id.clone(),
+            name: tc.fn_name.clone(),
+            arguments: tc.fn_arguments.clone(),
+        })
+        .collect();
+
+    // Extract usage
+    result.prompt_tokens = resp.usage.prompt_tokens.map(|t| t as u64);
+    result.completion_tokens = resp.usage.completion_tokens.map(|t| t as u64);
+
+    // Set finish reason based on whether there are tool calls
+    if !result.tool_calls.is_empty() {
+        result.finish_reason = Some("tool_calls".to_string());
+    } else {
+        result.finish_reason = Some("stop".to_string());
+    }
+
+    result
+}
+
+/// Extract text from genai MessageContent.
+fn extract_text_content(content: &MessageContent) -> String {
+    content.joined_texts().unwrap_or_default()
+}
+
+/// Extract tool calls from MessageContent.
+fn extract_tool_calls(content: &MessageContent) -> Vec<ParsedToolCall> {
+    content
+        .tool_calls()
+        .into_iter()
+        .map(|tc| ParsedToolCall {
+            id: tc.call_id.clone(),
+            name: tc.fn_name.clone(),
+            arguments: tc.fn_arguments.clone(),
+        })
+        .collect()
+}
+
+// ── Stream Event Conversions ────────────────────────────────────────────────
+
+/// Event types that can come from a chat stream, mapped to RustyClaw concepts.
+#[derive(Debug)]
+pub enum StreamEvent {
+    /// Stream has started.
+    Start,
+    /// Text content chunk.
+    TextChunk(String),
+    /// Reasoning/thinking content chunk.
+    ThinkingChunk(String),
+    /// Tool call is being streamed.
+    ToolCallChunk {
+        id: String,
+        name: String,
+        arguments_delta: String,
+    },
+    /// Stream has ended with final response data.
+    End { response: ModelResponse },
+}
+
+/// Convert a genai ChatStreamEvent to our StreamEvent.
+pub fn genai_stream_event_to_rc(event: ChatStreamEvent) -> StreamEvent {
+    match event {
+        ChatStreamEvent::Start => StreamEvent::Start,
+        ChatStreamEvent::Chunk(chunk) => StreamEvent::TextChunk(chunk.content),
+        ChatStreamEvent::ReasoningChunk(chunk) => StreamEvent::ThinkingChunk(chunk.content),
+        ChatStreamEvent::ThoughtSignatureChunk(chunk) => StreamEvent::ThinkingChunk(chunk.content),
+        ChatStreamEvent::ToolCallChunk(tc) => StreamEvent::ToolCallChunk {
+            id: tc.tool_call.call_id,
+            name: tc.tool_call.fn_name,
+            arguments_delta: tc.tool_call.fn_arguments.to_string(),
+        },
+        ChatStreamEvent::End(end) => {
+            let response = stream_end_to_model_response(&end);
+            StreamEvent::End { response }
+        }
+    }
+}
+
+/// Convert a StreamEnd to ModelResponse.
+pub fn stream_end_to_model_response(end: &StreamEnd) -> ModelResponse {
+    let mut response = ModelResponse::default();
+
+    // Extract accumulated content
+    if let Some(ref content) = end.captured_content {
+        response.text = extract_text_content(content);
+        response.tool_calls = extract_tool_calls(content);
+    }
+
+    // Extract usage
+    if let Some(ref usage) = end.captured_usage {
+        response.prompt_tokens = usage.prompt_tokens.map(|t| t as u64);
+        response.completion_tokens = usage.completion_tokens.map(|t| t as u64);
+    }
+
+    // Set finish reason
+    if !response.tool_calls.is_empty() {
+        response.finish_reason = Some("tool_calls".to_string());
+    } else {
+        response.finish_reason = Some("stop".to_string());
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rc_to_genai_user_message() {
+        let msg = RcChatMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+            ..Default::default()
+        };
+        let _genai_msg = rc_to_genai_message(&msg);
+        // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_extract_text_content_empty() {
+        let content = MessageContent::default();
+        assert_eq!(extract_text_content(&content), "");
+    }
+
+    #[test]
+    fn test_extract_text_content_single() {
+        let content = MessageContent::from_text("Hello world");
+        assert_eq!(extract_text_content(&content), "Hello world");
+    }
+}

--- a/crates/rustyclaw-core/src/genai_bridge.rs
+++ b/crates/rustyclaw-core/src/genai_bridge.rs
@@ -40,8 +40,9 @@ pub fn genai_to_rc_response(resp: &ChatResponse) -> ModelResponse {
     let mut result = ModelResponse::default();
 
     // Extract text content using the API
-    if let Some(text) = resp.first_text() {
-        result.text = text.to_string();
+    if let Some(ref content) = resp.content {
+        result.text = content.joined_texts().unwrap_or_default();
+    }
     }
 
     // Extract tool calls using the method

--- a/crates/rustyclaw-core/src/genai_bridge.rs
+++ b/crates/rustyclaw-core/src/genai_bridge.rs
@@ -6,8 +6,7 @@
 
 use crate::gateway::protocol::types::{ChatMessage as RcChatMessage, ModelResponse, ParsedToolCall};
 use genai::chat::{
-    ChatMessage as GenaiChatMessage, ChatResponse, ChatStreamEvent, MessageContent,
-    StreamEnd,
+    ChatMessage as GenaiChatMessage, ChatResponse, ChatStreamEvent, MessageContent, StreamEnd, Tool,
 };
 
 // ── Message Conversions ─────────────────────────────────────────────────────
@@ -31,6 +30,61 @@ pub fn rc_to_genai_message(msg: &RcChatMessage) -> GenaiChatMessage {
 /// Convert a slice of RustyClaw messages to genai messages.
 pub fn rc_to_genai_messages(messages: &[RcChatMessage]) -> Vec<GenaiChatMessage> {
     messages.iter().map(rc_to_genai_message).collect()
+}
+
+// ── Tool Conversions ────────────────────────────────────────────────────────
+
+/// Convert a single JSON tool definition to a genai [`Tool`].
+///
+/// Handles two common formats:
+///
+/// * **OpenAI / OpenAI-compatible**
+///   ```json
+///   { "type": "function", "function": { "name": "...", "description": "...", "parameters": { … } } }
+///   ```
+/// * **Flat** (Anthropic `input_schema` or Google `parameters`)
+///   ```json
+///   { "name": "...", "description": "...", "parameters": { … } }
+///   { "name": "...", "description": "...", "input_schema": { … } }
+///   ```
+pub fn json_value_to_genai_tool(value: &serde_json::Value) -> Tool {
+    // OpenAI / OpenAI-compatible: nested under "function" key.
+    if let Some(func) = value.get("function") {
+        let name = func
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let mut tool = Tool::new(name);
+        if let Some(desc) = func.get("description").and_then(|v| v.as_str()) {
+            tool = tool.with_description(desc);
+        }
+        if let Some(params) = func.get("parameters") {
+            tool = tool.with_schema(params.clone());
+        }
+        return tool;
+    }
+
+    // Flat format: name/description at top level, schema under "parameters" or "input_schema".
+    let name = value
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let mut tool = Tool::new(name);
+    if let Some(desc) = value.get("description").and_then(|v| v.as_str()) {
+        tool = tool.with_description(desc);
+    }
+    let schema = value
+        .get("parameters")
+        .or_else(|| value.get("input_schema"));
+    if let Some(schema) = schema {
+        tool = tool.with_schema(schema.clone());
+    }
+    tool
+}
+
+/// Convert a slice of JSON tool definitions to a `Vec<genai::chat::Tool>`.
+pub fn json_tools_to_genai(tools: &[serde_json::Value]) -> Vec<Tool> {
+    tools.iter().map(json_value_to_genai_tool).collect()
 }
 
 // ── Response Conversions ────────────────────────────────────────────────────

--- a/crates/rustyclaw-core/src/lib.rs
+++ b/crates/rustyclaw-core/src/lib.rs
@@ -27,6 +27,8 @@ pub mod pairing;
 pub mod process_manager;
 pub mod protocols;
 pub mod providers;
+pub mod provider_registry;
+pub mod genai_bridge;
 pub mod retry;
 pub mod runtime;
 pub mod runtime_ctx;

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -417,6 +417,80 @@ pub fn builtin_providers() -> HashMap<String, ProviderConfig> {
         },
     );
 
+    // Local inference servers
+    providers.insert(
+        "lmstudio".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: Some("http://localhost:1234/v1".to_string()),
+            api_key_env: None,
+            api_key_file: None,
+            api_key: None,
+            default_model: None,
+            display_name: Some("LM Studio (local)".to_string()),
+            help_url: Some("https://lmstudio.ai/".to_string()),
+        },
+    );
+
+    providers.insert(
+        "exo".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: Some("http://localhost:52415/v1".to_string()),
+            api_key_env: None,
+            api_key_file: None,
+            api_key: None,
+            default_model: None,
+            display_name: Some("exo (distributed)".to_string()),
+            help_url: Some("https://github.com/exo-explore/exo".to_string()),
+        },
+    );
+
+    // GitHub Copilot (device flow auth - uses OpenAI-compatible API)
+    providers.insert(
+        "github-copilot".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: Some("https://api.githubcopilot.com".to_string()),
+            api_key_env: Some("GITHUB_COPILOT_TOKEN".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("gpt-4o".to_string()),
+            display_name: Some("GitHub Copilot".to_string()),
+            help_url: Some("https://github.com/features/copilot".to_string()),
+        },
+    );
+
+    // Copilot proxy (for Copilot extensions)
+    providers.insert(
+        "copilot-proxy".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: Some("https://api.githubcopilot.com".to_string()),
+            api_key_env: Some("GITHUB_COPILOT_TOKEN".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("gpt-4o".to_string()),
+            display_name: Some("Copilot Proxy".to_string()),
+            help_url: None,
+        },
+    );
+
+    // Custom provider (user-defined)
+    providers.insert(
+        "custom".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: None, // Must be configured by user
+            api_key_env: Some("CUSTOM_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: None,
+            display_name: Some("Custom Provider".to_string()),
+            help_url: None,
+        },
+    );
+
     providers
 }
 

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -8,7 +8,7 @@ use genai::chat::{ChatMessage, ChatRequest, ChatResponse};
 use genai::resolver::AuthData;
 use genai::{Client, ClientBuilder, ModelIden, ServiceTarget};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -172,28 +172,50 @@ impl ProviderRegistry {
     /// - "provider/model" -> provider, model
     /// - "alias" -> resolved from model_aliases
     /// - "bare-model" -> auto-detect via genai
+    ///
+    /// Alias chains are followed iteratively; a cycle is detected via a visited
+    /// set and reported as an error naming the aliases involved.
     pub fn resolve(&self, model_ref: &str) -> Result<ResolvedModel> {
-        // Check aliases first
-        if let Some(resolved) = self.config.model_aliases.get(model_ref) {
-            return self.resolve(resolved);
-        }
+        let mut current = model_ref;
+        let mut visited: HashSet<&str> = HashSet::new();
 
-        // Check for provider/model format
-        if let Some((provider_id, model_name)) = model_ref.split_once('/') {
-            if let Some(config) = self.config.providers.get(provider_id) {
-                return Ok(ResolvedModel {
-                    provider_id: provider_id.to_string(),
-                    model_name: model_name.to_string(),
-                    config: config.clone(),
-                });
+        loop {
+            // Detect alias cycles before following the next alias.
+            if !visited.insert(current) {
+                anyhow::bail!(
+                    "Circular alias detected while resolving '{}': cycle involves [{}]",
+                    model_ref,
+                    visited
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
             }
-        }
 
-        // Fall back to genai auto-detection
-        anyhow::bail!(
-            "Cannot resolve model '{}'. Use 'provider/model' format or define an alias.",
-            model_ref
-        );
+            // Follow alias if one exists.
+            if let Some(next) = self.config.model_aliases.get(current) {
+                current = next.as_str();
+                continue;
+            }
+
+            // Check for provider/model format.
+            if let Some((provider_id, model_name)) = current.split_once('/') {
+                if let Some(config) = self.config.providers.get(provider_id) {
+                    return Ok(ResolvedModel {
+                        provider_id: provider_id.to_string(),
+                        model_name: model_name.to_string(),
+                        config: config.clone(),
+                    });
+                }
+            }
+
+            // No alias and not a provider/model reference.
+            anyhow::bail!(
+                "Cannot resolve model '{}'. Use 'provider/model' format or define an alias.",
+                current
+            );
+        }
     }
 
     /// Get the genai client for direct use.

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -1,0 +1,481 @@
+//! Config-driven provider registry using genai as the backend.
+//!
+//! This module provides a configuration-based approach to provider management,
+//! allowing new providers to be added via TOML config without code changes.
+
+use anyhow::{Context, Result};
+use genai::chat::{ChatMessage, ChatRequest, ChatResponse};
+use genai::resolver::AuthData;
+use genai::{Client, ClientBuilder, ModelIden, ServiceTarget};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::debug;
+
+// ── Configuration Types ─────────────────────────────────────────────────────
+
+/// Authentication method for a provider.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMethod {
+    /// API key from environment variable.
+    #[default]
+    ApiKeyEnv,
+    /// API key from file.
+    ApiKeyFile,
+    /// API key inline (not recommended for production).
+    ApiKeyInline,
+    /// No authentication required.
+    None,
+}
+
+/// Provider configuration from TOML.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProviderConfig {
+    /// API type: anthropic, openai, gemini, ollama, groq, xai, deepseek, cohere, openai-compatible
+    pub api: String,
+
+    /// Base URL override (required for openai-compatible, optional for others).
+    #[serde(default)]
+    pub base_url: Option<String>,
+
+    /// Environment variable name for API key.
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+
+    /// File path containing API key.
+    #[serde(default)]
+    pub api_key_file: Option<String>,
+
+    /// Inline API key (not recommended).
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Default model for this provider.
+    #[serde(default)]
+    pub default_model: Option<String>,
+
+    /// Display name for UI.
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    /// Help URL for getting API keys.
+    #[serde(default)]
+    pub help_url: Option<String>,
+}
+
+impl ProviderConfig {
+    /// Resolve the API key from configured source.
+    pub fn resolve_api_key(&self) -> Option<String> {
+        // Priority: inline > file > env
+        if let Some(ref key) = self.api_key {
+            return Some(key.clone());
+        }
+
+        if let Some(ref path) = self.api_key_file {
+            if let Ok(key) = std::fs::read_to_string(path) {
+                return Some(key.trim().to_string());
+            }
+        }
+
+        if let Some(ref env_var) = self.api_key_env {
+            if let Ok(key) = std::env::var(env_var) {
+                return Some(key);
+            }
+        }
+
+        None
+    }
+
+    /// Get the authentication method being used.
+    pub fn auth_method(&self) -> AuthMethod {
+        if self.api_key.is_some() {
+            AuthMethod::ApiKeyInline
+        } else if self.api_key_file.is_some() {
+            AuthMethod::ApiKeyFile
+        } else if self.api_key_env.is_some() {
+            AuthMethod::ApiKeyEnv
+        } else {
+            AuthMethod::None
+        }
+    }
+}
+
+/// Top-level provider registry configuration.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ProvidersConfig {
+    /// Provider configurations keyed by provider ID.
+    #[serde(default)]
+    pub providers: HashMap<String, ProviderConfig>,
+
+    /// Model aliases (e.g., "fast" -> "groq/llama-3.1-70b-versatile").
+    #[serde(default)]
+    pub model_aliases: HashMap<String, String>,
+}
+
+// ── Provider Registry ───────────────────────────────────────────────────────
+
+/// A resolved model reference.
+#[derive(Debug, Clone)]
+pub struct ResolvedModel {
+    pub provider_id: String,
+    pub model_name: String,
+    pub config: ProviderConfig,
+}
+
+/// Config-driven provider registry.
+pub struct ProviderRegistry {
+    config: Arc<ProvidersConfig>,
+    client: Client,
+}
+
+impl ProviderRegistry {
+    /// Create a new registry from configuration.
+    pub fn new(config: ProvidersConfig) -> Result<Self> {
+        let config = Arc::new(config);
+
+        // Create resolver closures that capture the config
+        let auth_config = Arc::clone(&config);
+        let target_config = Arc::clone(&config);
+
+        let client = ClientBuilder::default()
+            .with_auth_resolver_fn(move |model: ModelIden| -> genai::resolver::Result<Option<AuthData>> {
+                let provider_id = model.adapter_kind.as_str();
+                if let Some(provider) = auth_config.providers.get(provider_id) {
+                    if let Some(api_key) = provider.resolve_api_key() {
+                        debug!(provider = %provider_id, "Resolved API key from config");
+                        return Ok(Some(AuthData::from_single(api_key)));
+                    }
+                }
+                // Return None to fall back to genai defaults
+                Ok(None)
+            })
+            .with_service_target_resolver_fn(move |mut service_target: ServiceTarget| -> genai::resolver::Result<ServiceTarget> {
+                let provider_id = service_target.model.adapter_kind.as_str();
+                if let Some(provider) = target_config.providers.get(provider_id) {
+                    if let Some(ref base_url) = provider.base_url {
+                        debug!(provider = %provider_id, url = %base_url, "Using custom base URL");
+                        // Override the endpoint URL
+                        service_target.endpoint = genai::resolver::Endpoint::from_owned(base_url.clone());
+                    }
+                }
+                Ok(service_target)
+            })
+            .build();
+
+        Ok(Self { config, client })
+    }
+
+    /// Resolve a model reference to provider + model.
+    ///
+    /// Formats:
+    /// - "provider/model" -> provider, model
+    /// - "alias" -> resolved from model_aliases
+    /// - "bare-model" -> auto-detect via genai
+    pub fn resolve(&self, model_ref: &str) -> Result<ResolvedModel> {
+        // Check aliases first
+        if let Some(resolved) = self.config.model_aliases.get(model_ref) {
+            return self.resolve(resolved);
+        }
+
+        // Check for provider/model format
+        if let Some((provider_id, model_name)) = model_ref.split_once('/') {
+            if let Some(config) = self.config.providers.get(provider_id) {
+                return Ok(ResolvedModel {
+                    provider_id: provider_id.to_string(),
+                    model_name: model_name.to_string(),
+                    config: config.clone(),
+                });
+            }
+        }
+
+        // Fall back to genai auto-detection
+        anyhow::bail!(
+            "Cannot resolve model '{}'. Use 'provider/model' format or define an alias.",
+            model_ref
+        );
+    }
+
+    /// Get the genai client for direct use.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// List all configured providers.
+    pub fn providers(&self) -> Vec<&str> {
+        self.config.providers.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Get a provider's config by ID.
+    pub fn provider_config(&self, id: &str) -> Option<&ProviderConfig> {
+        self.config.providers.get(id)
+    }
+
+    /// Execute a chat request.
+    pub async fn chat(
+        &self,
+        model_ref: &str,
+        messages: Vec<ChatMessage>,
+    ) -> Result<ChatResponse> {
+        let resolved = self.resolve(model_ref)?;
+        let full_model = format!("{}/{}", resolved.provider_id, resolved.model_name);
+
+        let request = ChatRequest::new(messages);
+
+        self.client
+            .exec_chat(&full_model, request, None)
+            .await
+            .context("Chat request failed")
+    }
+
+    /// Execute a streaming chat request.
+    pub async fn chat_stream(
+        &self,
+        model_ref: &str,
+        messages: Vec<ChatMessage>,
+    ) -> Result<genai::chat::ChatStreamResponse> {
+        let resolved = self.resolve(model_ref)?;
+        let full_model = format!("{}/{}", resolved.provider_id, resolved.model_name);
+
+        let request = ChatRequest::new(messages);
+
+        self.client
+            .exec_chat_stream(&full_model, request, None)
+            .await
+            .context("Chat stream request failed")
+    }
+}
+
+// ── Built-in Provider Defaults ──────────────────────────────────────────────
+
+/// Get the default configuration for built-in providers.
+pub fn builtin_providers() -> HashMap<String, ProviderConfig> {
+    let mut providers = HashMap::new();
+
+    providers.insert(
+        "anthropic".to_string(),
+        ProviderConfig {
+            api: "anthropic".to_string(),
+            base_url: Some("https://api.anthropic.com".to_string()),
+            api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("claude-sonnet-4-20250514".to_string()),
+            display_name: Some("Anthropic (Claude)".to_string()),
+            help_url: Some("https://console.anthropic.com/settings/keys".to_string()),
+        },
+    );
+
+    providers.insert(
+        "openai".to_string(),
+        ProviderConfig {
+            api: "openai".to_string(),
+            base_url: Some("https://api.openai.com/v1".to_string()),
+            api_key_env: Some("OPENAI_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("gpt-4o".to_string()),
+            display_name: Some("OpenAI (GPT)".to_string()),
+            help_url: Some("https://platform.openai.com/api-keys".to_string()),
+        },
+    );
+
+    providers.insert(
+        "google".to_string(),
+        ProviderConfig {
+            api: "gemini".to_string(),
+            base_url: Some("https://generativelanguage.googleapis.com/v1beta".to_string()),
+            api_key_env: Some("GEMINI_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("gemini-2.5-pro".to_string()),
+            display_name: Some("Google (Gemini)".to_string()),
+            help_url: Some("https://aistudio.google.com/apikey".to_string()),
+        },
+    );
+
+    providers.insert(
+        "ollama".to_string(),
+        ProviderConfig {
+            api: "ollama".to_string(),
+            base_url: Some("http://localhost:11434".to_string()),
+            api_key_env: None,
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("llama3.1".to_string()),
+            display_name: Some("Ollama (local)".to_string()),
+            help_url: None,
+        },
+    );
+
+    providers.insert(
+        "groq".to_string(),
+        ProviderConfig {
+            api: "groq".to_string(),
+            base_url: Some("https://api.groq.com/openai/v1".to_string()),
+            api_key_env: Some("GROQ_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("llama-3.1-70b-versatile".to_string()),
+            display_name: Some("Groq".to_string()),
+            help_url: Some("https://console.groq.com/keys".to_string()),
+        },
+    );
+
+    providers.insert(
+        "xai".to_string(),
+        ProviderConfig {
+            api: "xai".to_string(),
+            base_url: Some("https://api.x.ai/v1".to_string()),
+            api_key_env: Some("XAI_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("grok-3".to_string()),
+            display_name: Some("xAI (Grok)".to_string()),
+            help_url: Some("https://console.x.ai/".to_string()),
+        },
+    );
+
+    providers.insert(
+        "deepseek".to_string(),
+        ProviderConfig {
+            api: "deepseek".to_string(),
+            base_url: Some("https://api.deepseek.com".to_string()),
+            api_key_env: Some("DEEPSEEK_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("deepseek-chat".to_string()),
+            display_name: Some("DeepSeek".to_string()),
+            help_url: Some("https://platform.deepseek.com/api_keys".to_string()),
+        },
+    );
+
+    providers.insert(
+        "openrouter".to_string(),
+        ProviderConfig {
+            api: "openai-compatible".to_string(),
+            base_url: Some("https://openrouter.ai/api/v1".to_string()),
+            api_key_env: Some("OPENROUTER_API_KEY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: Some("anthropic/claude-sonnet-4-20250514".to_string()),
+            display_name: Some("OpenRouter".to_string()),
+            help_url: Some("https://openrouter.ai/keys".to_string()),
+        },
+    );
+
+    providers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_config_resolve_api_key_from_env() {
+        // SAFETY: This test runs single-threaded and we clean up after
+        unsafe {
+            std::env::set_var("TEST_API_KEY_PROVIDER_REGISTRY", "test-key-123");
+        }
+
+        let config = ProviderConfig {
+            api: "openai".to_string(),
+            base_url: None,
+            api_key_env: Some("TEST_API_KEY_PROVIDER_REGISTRY".to_string()),
+            api_key_file: None,
+            api_key: None,
+            default_model: None,
+            display_name: None,
+            help_url: None,
+        };
+
+        assert_eq!(config.resolve_api_key(), Some("test-key-123".to_string()));
+
+        // SAFETY: Cleanup
+        unsafe {
+            std::env::remove_var("TEST_API_KEY_PROVIDER_REGISTRY");
+        }
+    }
+
+    #[test]
+    fn test_resolve_model_with_provider_prefix() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "anthropic".to_string(),
+            ProviderConfig {
+                api: "anthropic".to_string(),
+                base_url: None,
+                api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+                api_key_file: None,
+                api_key: None,
+                default_model: None,
+                display_name: None,
+                help_url: None,
+            },
+        );
+
+        let config = ProvidersConfig {
+            providers,
+            model_aliases: HashMap::new(),
+        };
+
+        let registry = ProviderRegistry::new(config).unwrap();
+        let resolved = registry.resolve("anthropic/claude-sonnet-4").unwrap();
+
+        assert_eq!(resolved.provider_id, "anthropic");
+        assert_eq!(resolved.model_name, "claude-sonnet-4");
+    }
+
+    #[test]
+    fn test_resolve_model_alias() {
+        let mut providers = HashMap::new();
+        providers.insert(
+            "groq".to_string(),
+            ProviderConfig {
+                api: "groq".to_string(),
+                base_url: None,
+                api_key_env: Some("GROQ_API_KEY".to_string()),
+                api_key_file: None,
+                api_key: None,
+                default_model: None,
+                display_name: None,
+                help_url: None,
+            },
+        );
+
+        let mut aliases = HashMap::new();
+        aliases.insert(
+            "fast".to_string(),
+            "groq/llama-3.1-70b-versatile".to_string(),
+        );
+
+        let config = ProvidersConfig {
+            providers,
+            model_aliases: aliases,
+        };
+
+        let registry = ProviderRegistry::new(config).unwrap();
+        let resolved = registry.resolve("fast").unwrap();
+
+        assert_eq!(resolved.provider_id, "groq");
+        assert_eq!(resolved.model_name, "llama-3.1-70b-versatile");
+    }
+
+    #[test]
+    fn test_builtin_providers() {
+        let providers = builtin_providers();
+
+        assert!(providers.contains_key("anthropic"));
+        assert!(providers.contains_key("openai"));
+        assert!(providers.contains_key("google"));
+        assert!(providers.contains_key("ollama"));
+        assert!(providers.contains_key("groq"));
+
+        let anthropic = &providers["anthropic"];
+        assert_eq!(anthropic.api, "anthropic");
+        assert_eq!(
+            anthropic.api_key_env,
+            Some("ANTHROPIC_API_KEY".to_string())
+        );
+    }
+}

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -307,19 +307,38 @@ impl ProviderRegistry {
     /// This is a bridge method that converts between RustyClaw's protocol types
     /// and genai's types, allowing gradual migration from the hand-rolled
     /// provider implementations.
+    ///
+    /// `tools` should be a slice of JSON tool definitions in OpenAI / OpenAI-compatible
+    /// format (`{ "type": "function", "function": { … } }`) or the flat
+    /// `{ "name", "description", "parameters" }` / Anthropic `input_schema` variants.
     pub async fn call_with_tools(
         &self,
         provider: &str,
         model: &str,
         messages: &[crate::gateway::protocol::types::ChatMessage],
-        _tools: Option<&[serde_json::Value]>, // TODO: wire up tool definitions
+        tools: Option<&[serde_json::Value]>,
     ) -> Result<crate::gateway::protocol::types::ModelResponse> {
-        use crate::genai_bridge::{genai_to_rc_response, rc_to_genai_messages};
+        use crate::genai_bridge::{genai_to_rc_response, json_tools_to_genai, rc_to_genai_messages};
 
         let model_ref = format!("{}/{}", provider, model);
-        let genai_messages = rc_to_genai_messages(messages);
+        let resolved = self.resolve(&model_ref)?;
+        let full_model = format!("{}/{}", resolved.provider_id, resolved.model_name);
 
-        let response = self.chat(&model_ref, genai_messages).await?;
+        let genai_messages = rc_to_genai_messages(messages);
+        let mut request = ChatRequest::new(genai_messages);
+
+        if let Some(tool_defs) = tools {
+            if !tool_defs.is_empty() {
+                request = request.with_tools(json_tools_to_genai(tool_defs));
+            }
+        }
+
+        let response = self
+            .client
+            .exec_chat(&full_model, request, None)
+            .await
+            .context("Chat request failed")?;
+
         Ok(genai_to_rc_response(&response))
     }
 }

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -211,6 +211,38 @@ impl ProviderRegistry {
         self.config.providers.get(id)
     }
 
+    /// Get the base URL for a provider.
+    pub fn base_url(&self, id: &str) -> Option<&str> {
+        self.config
+            .providers
+            .get(id)
+            .and_then(|p| p.base_url.as_deref())
+    }
+
+    /// Get the environment variable name for a provider's API key.
+    pub fn api_key_env(&self, id: &str) -> Option<&str> {
+        self.config
+            .providers
+            .get(id)
+            .and_then(|p| p.api_key_env.as_deref())
+    }
+
+    /// Get the display name for a provider.
+    pub fn display_name(&self, id: &str) -> Option<&str> {
+        self.config
+            .providers
+            .get(id)
+            .and_then(|p| p.display_name.as_deref())
+    }
+
+    /// Get the default model for a provider.
+    pub fn default_model(&self, id: &str) -> Option<&str> {
+        self.config
+            .providers
+            .get(id)
+            .and_then(|p| p.default_model.as_deref())
+    }
+
     /// Execute a chat request.
     pub async fn chat(
         &self,
@@ -243,6 +275,27 @@ impl ProviderRegistry {
             .exec_chat_stream(&full_model, request, None)
             .await
             .context("Chat stream request failed")
+    }
+
+    /// Execute a chat request with tools, using RustyClaw types.
+    ///
+    /// This is a bridge method that converts between RustyClaw's protocol types
+    /// and genai's types, allowing gradual migration from the hand-rolled
+    /// provider implementations.
+    pub async fn call_with_tools(
+        &self,
+        provider: &str,
+        model: &str,
+        messages: &[crate::gateway::protocol::types::ChatMessage],
+        _tools: Option<&[serde_json::Value]>, // TODO: wire up tool definitions
+    ) -> Result<crate::gateway::protocol::types::ModelResponse> {
+        use crate::genai_bridge::{genai_to_rc_response, rc_to_genai_messages};
+
+        let model_ref = format!("{}/{}", provider, model);
+        let genai_messages = rc_to_genai_messages(messages);
+
+        let response = self.chat(&model_ref, genai_messages).await?;
+        Ok(genai_to_rc_response(&response))
     }
 }
 

--- a/crates/rustyclaw-core/src/provider_registry.rs
+++ b/crates/rustyclaw-core/src/provider_registry.rs
@@ -174,24 +174,27 @@ impl ProviderRegistry {
     /// - "bare-model" -> auto-detect via genai
     ///
     /// Alias chains are followed iteratively; a cycle is detected via a visited
-    /// set and reported as an error naming the aliases involved.
+    /// set and reported as an error naming the exact aliases that form the cycle.
     pub fn resolve(&self, model_ref: &str) -> Result<ResolvedModel> {
         let mut current = model_ref;
+        // `path` preserves insertion order so we can slice out the exact cycle.
+        let mut path: Vec<&str> = Vec::new();
         let mut visited: HashSet<&str> = HashSet::new();
 
         loop {
-            // Detect alias cycles before following the next alias.
             if !visited.insert(current) {
+                // Find where in `path` the repeated alias first appeared and
+                // extract only that segment as the cycle description.
+                let cycle_start = path.iter().position(|&s| s == current).unwrap_or(0);
+                let cycle: Vec<&str> = path[cycle_start..].to_vec();
                 anyhow::bail!(
-                    "Circular alias detected while resolving '{}': cycle involves [{}]",
+                    "Circular alias detected while resolving '{}': {} -> {} (cycle)",
                     model_ref,
-                    visited
-                        .iter()
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    cycle.join(" -> "),
+                    current
                 );
             }
+            path.push(current);
 
             // Follow alias if one exists.
             if let Some(next) = self.config.model_aliases.get(current) {

--- a/crates/rustyclaw-desktop/src/components/settings.rs
+++ b/crates/rustyclaw-desktop/src/components/settings.rs
@@ -1,0 +1,91 @@
+use dioxus::prelude::*;
+use dioxus_bulma::prelude::*;
+use crate::state::AppState;
+
+#[component]
+pub fn SettingsDialog(
+    visible: Signal<bool>,
+    state: Signal<AppState>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let mut gateway_url = use_signal(|| state.read().gateway_url.clone());
+
+    let save_settings = move |_| {
+        state.write().gateway_url = gateway_url.read().clone();
+        on_close.call(());
+    };
+
+    rsx! {
+        div { 
+            class: "modal",
+            style: if *visible.read() { "display: block" } else { "display: none" },
+            div { class: "modal-background", onclick: move |_| on_close.call(()) }
+            div { 
+                class: "modal-card",
+                div { 
+                    class: "modal-card-head",
+                    p { class: "modal-card-title", "Settings" }
+                }
+                div { 
+                    class: "modal-card-body",
+                    div { 
+                        class: "field",
+                        div { 
+                            class: "field-label",
+                            label { class: "label", "Gateway URL" }
+                        }
+                        div { 
+                            class: "field-body",
+                            Input { 
+                                value: gateway_url.read().clone(),
+                                oninput: move |e| gateway_url.set(e),
+                                placeholder: "ws://127.0.0.1:9001",
+                            }
+                        }
+                    }
+                    div { 
+                        class: "field",
+                        div { 
+                            class: "field-label",
+                            label { class: "label", "Active Model" }
+                        }
+                        div { 
+                            class: "field-body",
+                            p { 
+                                class: "is-size-7", 
+                                "{state.read().model.as_deref().unwrap_or(\"None connected\")}" 
+                            }
+                        }
+                    }
+                    div { 
+                        class: "field",
+                        div { 
+                            class: "field-label",
+                            label { class: "label", "Provider" }
+                        }
+                        div { 
+                            class: "field-body",
+                            p { 
+                                class: "is-size-7", 
+                                "{state.read().provider.as_deref().unwrap_or(\"None connected\")}" 
+                            }
+                        }
+                    }
+                }
+                div { 
+                    class: "modal-card-foot",
+                    button { 
+                        class: "button", 
+                        onclick: move |_| on_close.call(()), 
+                        "Cancel" 
+                    }
+                    button { 
+                        class: "button is-primary", 
+                        onclick: save_settings, 
+                        "Save Changes" 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/rustyclaw-desktop/src/components/tool_approval.rs
+++ b/crates/rustyclaw-desktop/src/components/tool_approval.rs
@@ -1,0 +1,65 @@
+use dioxus::prelude::*;
+use dioxus_bulma::prelude::*;
+use crate::state::{AppState, ToolApprovalRequest};
+
+#[component]
+pub fn ToolApprovalDialog(
+    visible: Signal<<boolbool>,
+    request: Option<<ToolToolApprovalRequest>,
+    on_approve: EventHandler<<StringString>,
+    on_deny: EventHandler<<StringString>,
+) -> Element {
+    let Some(req) = request else {
+        return rsx! { div { } };
+    };
+
+    let call_id = req.call_id.clone();
+
+    rsx! {
+        div { 
+            class: "modal",
+            style: if *visible.read() { "display: block" } else { "display: none" },
+            div { class: "modal-background", onclick: move |_| on_deny.call(call_id.clone()) }
+            div { 
+                class: "modal-card",
+                div { 
+                    class: "modal-card-head",
+                    p { class: "modal-card-title", "Tool Call Approval" }
+                }
+                div { 
+                    class: "modal-card-body",
+                    div { 
+                        class: "content",
+                        p { 
+                            b { "Tool: " } 
+                            "{req.tool_name}" 
+                        }
+                        div { 
+                            class: "notification is-light",
+                            pre { 
+                                style: "white-space: pre-wrap; word-break: break-all;",
+                                "{req.arguments}" 
+                            }
+                        }
+                        p { 
+                            "The agent wants to execute this tool. Do you approve?" 
+                        }
+                    }
+                }
+                div { 
+                    class: "modal-card-foot",
+                    button { 
+                        class: "button is-danger", 
+                        onclick: move |_| on_deny.call(call_id.clone()), 
+                        "Deny" 
+                    }
+                    button { 
+                        class: "button is-success", 
+                        onclick: move |_| on_approve.call(call_id.clone()), 
+                        "Approve" 
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 implementation of Issue #176: Config-driven provider management using the genai crate.

## Changes

### New Modules

**provider_registry.rs** (~500 lines)
- ProvidersConfig: TOML-based provider configuration
- ProviderRegistry: Runtime provider management
- builtin_providers(): Defaults for 13 providers
- call_with_tools(): Bridge method for RustyClaw types

**genai_bridge.rs** (~150 lines)
- Type conversions between genai and RustyClaw

### Providers Supported
All 13 from static PROVIDERS array: anthropic, openai, google, xai, groq, deepseek, openrouter, ollama, lmstudio, exo, github-copilot, copilot-proxy, custom

## Next Steps
1. Wire ProviderRegistry into gateway startup
2. Replace call_*_with_tools functions
3. Remove ~2400 lines of redundant provider code

Closes #176
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rexlunae/rustyclaw/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
