### PR TITLE
ui(tui): compact tool-call panels, suppress empty tool bubbles

### DIFF
--- a/crates/rustyclaw-core/src/secrets/vault_ext.rs
+++ b/crates/rustyclaw-core/src/secrets/vault_ext.rs
@@ -100,9 +100,8 @@ impl SecretsManager {
         use ssh_key::private::PrivateKey;
 
         // Generate keypair.
-        let private =
-            PrivateKey::random(&mut rand::rng(), ssh_key::Algorithm::Ed25519)
-                .map_err(|e| anyhow::anyhow!("Failed to generate SSH key: {}", e))?;
+        let private = PrivateKey::random(&mut rand::rng(), ssh_key::Algorithm::Ed25519)
+            .map_err(|e| anyhow::anyhow!("Failed to generate SSH key: {}", e))?;
 
         let private_pem = private
             .to_openssh(ssh_key::LineEnding::LF)

--- a/crates/rustyclaw-gateway/src/ssh/server.rs
+++ b/crates/rustyclaw-gateway/src/ssh/server.rs
@@ -46,11 +46,9 @@ impl SshServer {
 
             // Generate a new Ed25519 key. Use ssh-key's re-exported OsRng so the
             // rand_core version matches russh (its OsRng impls CryptoRng).
-            let key = russh::keys::PrivateKey::random(
-                &mut rand::rng(),
-                russh::keys::Algorithm::Ed25519,
-            )
-            .context("Failed to generate host key")?;
+            let key =
+                russh::keys::PrivateKey::random(&mut rand::rng(), russh::keys::Algorithm::Ed25519)
+                    .context("Failed to generate host key")?;
 
             // Ensure parent directory exists
             if let Some(parent) = ssh_config.host_key_path.parent() {

--- a/crates/rustyclaw-tui/src/components/messages.rs
+++ b/crates/rustyclaw-tui/src/components/messages.rs
@@ -58,7 +58,7 @@ pub fn Messages(props: &MessagesProps) -> impl Into<AnyElement<'static>> {
                     // An assistant turn that only carries tool calls has empty
                     // text — don't render an empty bubble box (which would also
                     // show an action bar). Render just the tool panels instead.
-                    let show_bubble = !(msg.content.trim().is_empty() && !msg.tool_calls.is_empty());
+                    let show_bubble = !msg.content.trim().is_empty() || msg.tool_calls.is_empty();
                     element! {
                         View(
                             key: i as u64,

--- a/crates/rustyclaw-tui/src/components/messages.rs
+++ b/crates/rustyclaw-tui/src/components/messages.rs
@@ -55,16 +55,26 @@ pub fn Messages(props: &MessagesProps) -> impl Into<AnyElement<'static>> {
                     let name = assistant_name.clone();
                     let has_details = latest_details_idx == Some(i);
                     let bubble_data = msg.to_bubble_data(name, has_details);
+                    // An assistant turn that only carries tool calls has empty
+                    // text — don't render an empty bubble box (which would also
+                    // show an action bar). Render just the tool panels instead.
+                    let show_bubble = !(msg.content.trim().is_empty() && !msg.tool_calls.is_empty());
                     element! {
                         View(
                             key: i as u64,
                             flex_direction: FlexDirection::Column,
                             width: 100pct,
                         ) {
-                            MessageBubble(
-                                data: bubble_data,
-                                is_selected: props.selected_idx == Some(i),
-                            )
+                            #(if show_bubble {
+                                element! {
+                                    MessageBubble(
+                                        data: bubble_data,
+                                        is_selected: props.selected_idx == Some(i),
+                                    )
+                                }.into_any()
+                            } else {
+                                element! { View() }.into_any()
+                            })
                             #(msg.tool_calls.iter().enumerate().map(|(ti, tool)| {
                                 element! {
                                     ToolCallPanel(

--- a/crates/rustyclaw-tui/src/components/tool_call.rs
+++ b/crates/rustyclaw-tui/src/components/tool_call.rs
@@ -9,32 +9,69 @@ pub struct ToolCallPanelProps {
 #[component]
 pub fn ToolCallPanel(props: &ToolCallPanelProps) -> impl Into<AnyElement<'static>> {
     let (_, status_label, status_icon) = props.data.status_label();
-    let status = format!("{status_icon} {status_label}");
+    let color = if props.data.is_error {
+        theme::ERROR
+    } else {
+        theme::INFO
+    };
 
-    let args = props.data.arguments_preview(600, 12);
-    let result = props.data.result_preview(2000, 40);
+    // Collapsed (default) → single dim line: header + status + arg/result peek.
+    // Expanded → header line plus truncated args and result beneath.
+    let collapsed = props.data.collapsed;
+
+    let header = format!("{} · {} {}", props.data.summary(), status_icon, status_label);
+
+    // Short inline peek shown when collapsed so the row is one line but still
+    // hints at what ran / what came back.
+    let peek = if collapsed {
+        let src = props
+            .data
+            .result_preview(80, 1)
+            .unwrap_or_else(|| props.data.arguments_preview(80, 1));
+        let one = src.replace('\n', " ");
+        if one.trim().is_empty() {
+            String::new()
+        } else {
+            format!("  {one}")
+        }
+    } else {
+        String::new()
+    };
+
+    let args = if collapsed {
+        String::new()
+    } else {
+        props.data.arguments_preview(600, 12)
+    };
+    let result = if collapsed {
+        None
+    } else {
+        props.data.result_preview(2000, 40)
+    };
 
     element! {
         View(
             width: 100pct,
-            margin_bottom: 1,
             padding_left: 2,
             padding_right: 1,
-            border_style: BorderStyle::Round,
-            border_color: if props.data.is_error { theme::ERROR } else { theme::INFO },
-            border_edges: Edges::Left,
             flex_direction: FlexDirection::Column,
         ) {
             Text(
-                content: format!("{} · {}", props.data.summary(), status),
-                color: if props.data.is_error { theme::ERROR } else { theme::ACCENT },
-                weight: Weight::Bold,
+                content: format!("{header}{peek}"),
+                color,
+                weight: if collapsed { Weight::Normal } else { Weight::Bold },
             )
-            Text(content: args, color: theme::TEXT_DIM, wrap: TextWrap::Wrap)
+            #(if !args.is_empty() {
+                element! {
+                    Text(content: format!("→ {args}"), color: theme::TEXT_DIM, wrap: TextWrap::Wrap)
+                }.into_any()
+            } else {
+                element! { View() }.into_any()
+            })
             #(if let Some(result) = result {
                 element! {
                     Text(
-                        content: result,
+                        content: format!("↳ {result}"),
                         color: if props.data.is_error { theme::ERROR } else { theme::TEXT },
                         wrap: TextWrap::Wrap,
                     )

--- a/crates/rustyclaw-tui/src/components/tool_call.rs
+++ b/crates/rustyclaw-tui/src/components/tool_call.rs
@@ -19,7 +19,12 @@ pub fn ToolCallPanel(props: &ToolCallPanelProps) -> impl Into<AnyElement<'static
     // Expanded → header line plus truncated args and result beneath.
     let collapsed = props.data.collapsed;
 
-    let header = format!("{} · {} {}", props.data.summary(), status_icon, status_label);
+    let header = format!(
+        "{} · {} {}",
+        props.data.summary(),
+        status_icon,
+        status_label
+    );
 
     // Short inline peek shown when collapsed so the row is one line but still
     // hints at what ran / what came back.


### PR DESCRIPTION
Collapsed tool calls render as a single dim line; expanded shows args (→) and result (↳) for a clear call→result link. Tool-only assistant turns no longer draw an empty bubble + action bar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rexlunae/rustyclaw/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->