### PR TITLE
ui(desktop): pin composer to bottom, modernize send/stop button

### DIFF
--- a/crates/rustyclaw-desktop/assets/styles.css
+++ b/crates/rustyclaw-desktop/assets/styles.css
@@ -634,6 +634,47 @@ body,
 
 /* ── 5. Composer ────────────────────────────────────────────────────────── */
 
+/* Pin the composer to the bottom of the chat column so it never scrolls
+   offscreen. The embedded ChatSurface renders transcript + input box +
+   buttons in document order inside .chat-scroll; the input box and button
+   row are sticky so they stay anchored while the transcript scrolls. */
+.gc-embedded .gc-input-box {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    background: var(--rc-bg);
+    padding: 8px 0 0;
+    border-top: 1px solid var(--rc-border);
+}
+
+/* The textarea is the bubble; give it room on the right for the send button. */
+.gc-embedded .gc-input-box .textarea {
+    border-radius: 14px;
+    padding-right: 56px;
+    resize: none;
+}
+
+/* Compact, modern Send/Stop kept pinned bottom-right with the composer. */
+.gc-embedded .buttons {
+    position: sticky;
+    bottom: 0;
+    z-index: 6;
+    justify-content: flex-end;
+    background: var(--rc-bg);
+    margin: 0;
+    padding: 8px 0 10px;
+}
+
+.gc-embedded .buttons .button {
+    border-radius: 999px;
+    min-width: 40px;
+    height: 40px;
+    padding: 0 18px;
+    font-weight: 600;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    margin: 0;
+}
+
 .model-bar {
     display: flex;
     gap: 6px;


### PR DESCRIPTION
Composer input box is now sticky so it stays anchored while the transcript scrolls instead of scrolling offscreen. Send/Stop is a compact pill button aligned bottom-right with a rounded textarea, replacing the full-width bar that hung off the bottom.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rexlunae/rustyclaw/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->